### PR TITLE
Add SonarQube system API support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -25,3 +25,4 @@ pnpm-debug.log*
 # OS files
 .DS_Store
 Thumbs.db 
+**/.claude/settings.local.json

--- a/src/__tests__/sonarqube.test.ts
+++ b/src/__tests__/sonarqube.test.ts
@@ -451,4 +451,70 @@ describe('SonarQubeClient', () => {
       expect(scope.isDone()).toBe(true);
     });
   });
+
+  describe('getHealth', () => {
+    it('should fetch health status successfully', async () => {
+      const mockResponse = {
+        health: 'GREEN',
+        causes: [],
+      };
+
+      nock(baseUrl)
+        .get('/api/system/health')
+        .basicAuth({ user: token, pass: '' })
+        .reply(200, mockResponse);
+
+      const result = await client.getHealth();
+      expect(result).toEqual(mockResponse);
+      expect(result.health).toBe('GREEN');
+      expect(result.causes).toEqual([]);
+    });
+
+    it('should handle warning health status', async () => {
+      const mockResponse = {
+        health: 'YELLOW',
+        causes: ['Disk space low'],
+      };
+
+      nock(baseUrl)
+        .get('/api/system/health')
+        .basicAuth({ user: token, pass: '' })
+        .reply(200, mockResponse);
+
+      const result = await client.getHealth();
+      expect(result).toEqual(mockResponse);
+      expect(result.health).toBe('YELLOW');
+      expect(result.causes).toContain('Disk space low');
+    });
+  });
+
+  describe('getStatus', () => {
+    it('should fetch system status successfully', async () => {
+      const mockResponse = {
+        id: '20230101-1234',
+        version: '10.3.0.82913',
+        status: 'UP',
+      };
+
+      nock(baseUrl)
+        .get('/api/system/status')
+        .basicAuth({ user: token, pass: '' })
+        .reply(200, mockResponse);
+
+      const result = await client.getStatus();
+      expect(result).toEqual(mockResponse);
+      expect(result.id).toBe('20230101-1234');
+      expect(result.version).toBe('10.3.0.82913');
+      expect(result.status).toBe('UP');
+    });
+  });
+
+  describe('ping', () => {
+    it('should ping SonarQube successfully', async () => {
+      nock(baseUrl).get('/api/system/ping').basicAuth({ user: token, pass: '' }).reply(200, 'pong');
+
+      const result = await client.ping();
+      expect(result).toBe('pong');
+    });
+  });
 });

--- a/src/index.ts
+++ b/src/index.ts
@@ -193,6 +193,57 @@ export async function handleSonarQubeGetMetrics(params: PaginationParams) {
   };
 }
 
+/**
+ * Handler for getting SonarQube system health status
+ * @returns Promise with the health status result
+ */
+export async function handleSonarQubeGetHealth() {
+  const result = await client.getHealth();
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(result),
+      },
+    ],
+  };
+}
+
+/**
+ * Handler for getting SonarQube system status
+ * @returns Promise with the system status result
+ */
+export async function handleSonarQubeGetStatus() {
+  const result = await client.getStatus();
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: JSON.stringify(result),
+      },
+    ],
+  };
+}
+
+/**
+ * Handler for pinging SonarQube system
+ * @returns Promise with the ping result
+ */
+export async function handleSonarQubePing() {
+  const result = await client.ping();
+
+  return {
+    content: [
+      {
+        type: 'text' as const,
+        text: result,
+      },
+    ],
+  };
+}
+
 // Define SonarQube severity schema for validation
 const severitySchema = z
   .enum(['INFO', 'MINOR', 'MAJOR', 'CRITICAL', 'BLOCKER'])
@@ -320,6 +371,28 @@ mcpServer.tool(
   async (params: Record<string, unknown>) => {
     return handleSonarQubeGetIssues(mapToSonarQubeParams(params));
   }
+);
+
+// Register system API tools
+mcpServer.tool(
+  'system_health',
+  'Get the health status of the SonarQube instance',
+  {},
+  handleSonarQubeGetHealth
+);
+
+mcpServer.tool(
+  'system_status',
+  'Get the status of the SonarQube instance',
+  {},
+  handleSonarQubeGetStatus
+);
+
+mcpServer.tool(
+  'system_ping',
+  'Ping the SonarQube instance to check if it is up',
+  {},
+  handleSonarQubePing
 );
 
 // Only start the server if not in test mode

--- a/src/sonarqube.ts
+++ b/src/sonarqube.ts
@@ -269,6 +269,29 @@ export interface SonarQubeMetricsResult {
 }
 
 /**
+ * Interface for SonarQube health status
+ */
+export interface SonarQubeHealthStatus {
+  health: 'GREEN' | 'YELLOW' | 'RED';
+  causes: string[];
+}
+
+/**
+ * Interface for SonarQube system status
+ */
+export interface SonarQubeSystemStatus {
+  id: string;
+  version: string;
+  status:
+    | 'UP'
+    | 'DOWN'
+    | 'STARTING'
+    | 'RESTARTING'
+    | 'DB_MIGRATION_NEEDED'
+    | 'DB_MIGRATION_RUNNING';
+}
+
+/**
  * SonarQube client for interacting with the SonarQube API
  */
 export class SonarQubeClient {
@@ -410,5 +433,41 @@ export class SonarQubeClient {
       metrics: response.data.metrics,
       paging: response.data.paging,
     };
+  }
+
+  /**
+   * Gets the health status of the SonarQube instance
+   * @returns Promise with the health status
+   */
+  async getHealth(): Promise<SonarQubeHealthStatus> {
+    const response = await axios.get(`${this.baseUrl}/api/system/health`, {
+      auth: this.auth,
+    });
+
+    return response.data;
+  }
+
+  /**
+   * Gets the system status of the SonarQube instance
+   * @returns Promise with the system status
+   */
+  async getStatus(): Promise<SonarQubeSystemStatus> {
+    const response = await axios.get(`${this.baseUrl}/api/system/status`, {
+      auth: this.auth,
+    });
+
+    return response.data;
+  }
+
+  /**
+   * Pings the SonarQube instance to check if it's up
+   * @returns Promise with the ping response
+   */
+  async ping(): Promise<string> {
+    const response = await axios.get(`${this.baseUrl}/api/system/ping`, {
+      auth: this.auth,
+    });
+
+    return response.data;
   }
 }


### PR DESCRIPTION
## Summary
- Adds support for SonarQube system API endpoints: health, status, and ping
- Implements client methods, handlers, and MCP tools for these endpoints
- Includes comprehensive tests for all new functionality

## Test plan
- All unit tests are passing
- Manually test the following endpoints:
  - `system_health` - Returns health status of the SonarQube instance
  - `system_status` - Returns system status including version and state
  - `system_ping` - Simple ping endpoint for availability checks

🤖 Generated with [Claude Code](https://claude.ai/code)