### PR TITLE
Allow Filtering SonarQube Issues by Branch, Pull Request, and Hotspots

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,9 @@ The SonarQube MCP Server provides the following tools:
 2. `issues`: Get issues from a SonarQube project
    * Parameters:
      * `project_key` (required) - The unique identifier for the SonarQube project
+     * `branch` (optional) - Filter issues for a specific branch
+     * `pull_request` (optional) - Filter issues for a specific pull request
+     * `hotspots` (optional) - Filter for security hotspots
      * `severity` (optional) - Filter issues by severity (INFO, MINOR, MAJOR, CRITICAL, BLOCKER)
      * `organization` (optional) - Organization key for SonarQube Cloud
      * `page` (optional) - Page number for results pagination
@@ -188,4 +191,4 @@ pnpm run build
 
 ## License
 
-MIT 
+MIT

--- a/src/sonarqube.ts
+++ b/src/sonarqube.ts
@@ -194,6 +194,7 @@ export interface SonarQubeProjectsResult {
  */
 export interface IssuesParams extends PaginationParams {
   projectKey: string;
+  branch?: string;
   severity?: 'INFO' | 'MINOR' | 'MAJOR' | 'CRITICAL' | 'BLOCKER';
   statuses?: (
     | 'OPEN'
@@ -225,6 +226,8 @@ export interface IssuesParams extends PaginationParams {
   facets?: string[];
   sinceLeakPeriod?: boolean;
   inNewCodePeriod?: boolean;
+  pullRequest?: string;
+  hotspots?: boolean;
 }
 
 /**
@@ -351,6 +354,7 @@ export class SonarQubeClient {
   async getIssues(params: IssuesParams): Promise<SonarQubeIssuesResult> {
     const {
       projectKey,
+      branch,
       severity,
       page,
       pageSize,
@@ -375,12 +379,15 @@ export class SonarQubeClient {
       facets,
       sinceLeakPeriod,
       inNewCodePeriod,
+      pullRequest,
+      hotspots,
     } = params;
 
     const response = await axios.get(`${this.baseUrl}/api/issues/search`, {
       auth: this.auth,
       params: {
         componentKeys: projectKey,
+        branch,
         severities: severity,
         organization: this.organization,
         p: page,
@@ -406,6 +413,8 @@ export class SonarQubeClient {
         facets: facets?.join(','),
         sinceLeakPeriod,
         inNewCodePeriod,
+        pullRequest,
+        hotspots,
       },
     });
 


### PR DESCRIPTION
## Allow Filtering SonarQube Issues by Branch, Pull Request, and Hotspots

### Summary

This PR adds support for filtering issues from SonarQube by `branch`, `pullRequest`, and `hotspots` in the MCP server. The following changes are included:

- **`branch` parameter**:  enables fetching issues on current branch, so you can fix them easily 
- **`pullRequest` parameter**: enables fetching issues on current pr, so you can fix them easily 
- **`hotspots` parameter**: Adds the ability to filter for security hotspots, helping teams focus on potential security risks.

### Additional

- Updated the README to document the new parameters.

---

Let me know if you want me to add or change anything