### PR TITLE
chore: Rename tools to follow MCP naming conventions

### DIFF
--- a/README.md
+++ b/README.md
@@ -355,7 +355,7 @@ Get issues from SonarQube projects with advanced filtering, sorting, and branch/
 
 ### Security Hotspots
 
-#### `search_hotspots`
+#### `hotspots`
 Search for security hotspots with specialized filters for security review workflows.
 
 **Parameters:**
@@ -371,7 +371,7 @@ Search for security hotspots with specialized filters for security review workfl
 - `page` (optional): Page number for pagination
 - `page_size` (optional): Number of items per page
 
-#### `get_hotspot_details`
+#### `hotspot`
 Get detailed information about a specific security hotspot including security context.
 
 **Parameters:**
@@ -406,7 +406,7 @@ Get quality gate conditions.
 **Parameters:**
 - `id` (required): Quality gate ID
 
-#### `project_quality_gate_status`
+#### `quality_gate_status`
 Get project quality gate status.
 
 **Parameters:**

--- a/src/__tests__/quality-gates.test.ts
+++ b/src/__tests__/quality-gates.test.ts
@@ -3,7 +3,7 @@ import { createSonarQubeClient, SonarQubeClient, ProjectQualityGateParams } from
 import {
   handleSonarQubeListQualityGates,
   handleSonarQubeGetQualityGate,
-  handleSonarQubeProjectQualityGateStatus,
+  handleSonarQubeQualityGateStatus,
 } from '../index.js';
 
 describe('SonarQube Quality Gates API', () => {
@@ -225,7 +225,7 @@ describe('SonarQube Quality Gates API', () => {
         .query({ projectKey: params.projectKey })
         .reply(200, mockResponse);
 
-      const response = await handleSonarQubeProjectQualityGateStatus(params, client);
+      const response = await handleSonarQubeQualityGateStatus(params, client);
       expect(response).toHaveProperty('content');
       expect(response.content).toHaveLength(1);
       expect(response.content[0].type).toBe('text');

--- a/src/__tests__/sonarqube.test.ts
+++ b/src/__tests__/sonarqube.test.ts
@@ -1574,7 +1574,7 @@ describe('SonarQubeClient', () => {
         .matchHeader('authorization', 'Bearer test-token')
         .reply(200, mockResponse);
 
-      const result = await client.searchHotspots({
+      const result = await client.hotspots({
         projectKey: 'my-project',
         status: 'TO_REVIEW',
         page: 1,
@@ -1610,7 +1610,7 @@ describe('SonarQubeClient', () => {
         .matchHeader('authorization', 'Bearer test-token')
         .reply(200, mockResponse);
 
-      await client.searchHotspots({
+      await client.hotspots({
         projectKey: 'my-project',
         branch: 'feature-branch',
         pullRequest: 'PR-123',
@@ -1667,7 +1667,7 @@ describe('SonarQubeClient', () => {
         .matchHeader('authorization', 'Bearer test-token')
         .reply(200, mockResponse);
 
-      const result = await client.getHotspotDetails('AYg1234567890');
+      const result = await client.hotspot('AYg1234567890');
 
       expect(result).toEqual(mockResponse);
       expect(scope.isDone()).toBe(true);

--- a/src/index.ts
+++ b/src/index.ts
@@ -542,7 +542,7 @@ export async function handleSonarQubeGetQualityGate(
  * @param client Optional SonarQube client instance
  * @returns Promise with the project quality gate status
  */
-export async function handleSonarQubeProjectQualityGateStatus(
+export async function handleSonarQubeQualityGateStatus(
   params: ProjectQualityGateParams,
   client: ISonarQubeClient = getDefaultClient()
 ) {
@@ -608,11 +608,11 @@ export async function handleSonarQubeGetScmBlame(
  * @param client Optional SonarQube client instance
  * @returns Promise with the hotspot search results
  */
-export async function handleSonarQubeSearchHotspots(
+export async function handleSonarQubeHotspots(
   params: HotspotSearchParams,
   client: ISonarQubeClient = getDefaultClient()
 ) {
-  const result = await client.searchHotspots(params);
+  const result = await client.hotspots(params);
 
   return {
     content: [
@@ -630,11 +630,11 @@ export async function handleSonarQubeSearchHotspots(
  * @param client Optional SonarQube client instance
  * @returns Promise with the hotspot details
  */
-export async function handleSonarQubeGetHotspotDetails(
+export async function handleSonarQubeHotspot(
   hotspotKey: string,
   client: ISonarQubeClient = getDefaultClient()
 ) {
-  const result = await client.getHotspotDetails(hotspotKey);
+  const result = await client.hotspot(hotspotKey);
 
   return {
     content: [
@@ -824,10 +824,10 @@ export const qualityGateHandler = async (params: Record<string, unknown>) => {
 };
 
 /**
- * Lambda function for project_quality_gate_status tool
+ * Lambda function for quality_gate_status tool
  */
-export const projectQualityGateStatusHandler = async (params: Record<string, unknown>) => {
-  return handleSonarQubeProjectQualityGateStatus({
+export const qualityGateStatusHandler = async (params: Record<string, unknown>) => {
+  return handleSonarQubeQualityGateStatus({
     projectKey: params.project_key as string,
     branch: params.branch as string | undefined,
     pullRequest: params.pull_request as string | undefined,
@@ -863,8 +863,8 @@ export const scmBlameHandler = async (params: Record<string, unknown>) => {
 /**
  * Lambda function for search_hotspots tool
  */
-export const searchHotspotsHandler = async (params: Record<string, unknown>) => {
-  return handleSonarQubeSearchHotspots({
+export const hotspotsHandler = async (params: Record<string, unknown>) => {
+  return handleSonarQubeHotspots({
     projectKey: params.project_key as string | undefined,
     branch: params.branch as string | undefined,
     pullRequest: params.pull_request as string | undefined,
@@ -882,8 +882,8 @@ export const searchHotspotsHandler = async (params: Record<string, unknown>) => 
 /**
  * Lambda function for get_hotspot_details tool
  */
-export const getHotspotDetailsHandler = async (params: Record<string, unknown>) => {
-  return handleSonarQubeGetHotspotDetails(params.hotspot_key as string);
+export const hotspotHandler = async (params: Record<string, unknown>) => {
+  return handleSonarQubeHotspot(params.hotspot_key as string);
 };
 
 /**
@@ -915,14 +915,12 @@ export const measuresHistoryMcpHandler = (params: Record<string, unknown>) =>
 export const qualityGatesMcpHandler = () => qualityGatesHandler();
 export const qualityGateMcpHandler = (params: Record<string, unknown>) =>
   qualityGateHandler(params);
-export const projectQualityGateStatusMcpHandler = (params: Record<string, unknown>) =>
-  projectQualityGateStatusHandler(params);
+export const qualityGateStatusMcpHandler = (params: Record<string, unknown>) =>
+  qualityGateStatusHandler(params);
 export const sourceCodeMcpHandler = (params: Record<string, unknown>) => sourceCodeHandler(params);
 export const scmBlameMcpHandler = (params: Record<string, unknown>) => scmBlameHandler(params);
-export const searchHotspotsMcpHandler = (params: Record<string, unknown>) =>
-  searchHotspotsHandler(params);
-export const getHotspotDetailsMcpHandler = (params: Record<string, unknown>) =>
-  getHotspotDetailsHandler(params);
+export const hotspotsMcpHandler = (params: Record<string, unknown>) => hotspotsHandler(params);
+export const hotspotMcpHandler = (params: Record<string, unknown>) => hotspotHandler(params);
 export const updateHotspotStatusMcpHandler = (params: Record<string, unknown>) =>
   updateHotspotStatusHandler(params);
 
@@ -1121,14 +1119,14 @@ mcpServer.tool(
 );
 
 mcpServer.tool(
-  'project_quality_gate_status',
+  'quality_gate_status',
   'Get project quality gate status',
   {
     project_key: z.string(),
     branch: z.string().optional(),
     pull_request: z.string().optional(),
   },
-  projectQualityGateStatusMcpHandler
+  qualityGateStatusMcpHandler
 );
 
 // Register Source Code API tools
@@ -1160,7 +1158,7 @@ mcpServer.tool(
 
 // Register Security Hotspot tools
 mcpServer.tool(
-  'search_hotspots',
+  'hotspots',
   'Search for security hotspots with filtering options',
   {
     project_key: z.string().optional(),
@@ -1184,16 +1182,16 @@ mcpServer.tool(
     page: z.string().optional().transform(stringToNumberTransform),
     page_size: z.string().optional().transform(stringToNumberTransform),
   },
-  searchHotspotsMcpHandler
+  hotspotsMcpHandler
 );
 
 mcpServer.tool(
-  'get_hotspot_details',
+  'hotspot',
   'Get detailed information about a specific security hotspot',
   {
     hotspot_key: z.string(),
   },
-  getHotspotDetailsMcpHandler
+  hotspotMcpHandler
 );
 
 mcpServer.tool(

--- a/src/sonarqube.ts
+++ b/src/sonarqube.ts
@@ -742,8 +742,8 @@ export interface ISonarQubeClient {
   getScmBlame(params: ScmBlameParams): Promise<SonarQubeScmBlameResult>;
 
   // Security Hotspots API methods
-  searchHotspots(params: HotspotSearchParams): Promise<SonarQubeHotspotSearchResult>;
-  getHotspotDetails(hotspotKey: string): Promise<SonarQubeHotspotDetails>;
+  hotspots(params: HotspotSearchParams): Promise<SonarQubeHotspotSearchResult>;
+  hotspot(hotspotKey: string): Promise<SonarQubeHotspotDetails>;
   updateHotspotStatus(params: HotspotStatusUpdateParams): Promise<void>;
 }
 
@@ -1200,7 +1200,7 @@ export class SonarQubeClient implements ISonarQubeClient {
    * @param params Parameters for hotspot search
    * @returns Promise with the hotspot search results
    */
-  async searchHotspots(params: HotspotSearchParams): Promise<SonarQubeHotspotSearchResult> {
+  async hotspots(params: HotspotSearchParams): Promise<SonarQubeHotspotSearchResult> {
     const {
       projectKey,
       // branch, pullRequest, inNewCodePeriod are not currently supported by the API
@@ -1248,7 +1248,7 @@ export class SonarQubeClient implements ISonarQubeClient {
    * @param hotspotKey The key of the hotspot
    * @returns Promise with the hotspot details
    */
-  async getHotspotDetails(hotspotKey: string): Promise<SonarQubeHotspotDetails> {
+  async hotspot(hotspotKey: string): Promise<SonarQubeHotspotDetails> {
     const response = await this.webApiClient.hotspots.show({
       hotspot: hotspotKey,
     });


### PR DESCRIPTION
## Summary
- Renamed `search_hotspots` to `hotspots` for consistency
- Renamed `get_hotspot_details` to `hotspot` following singular noun convention
- Renamed `project_quality_gate_status` to `quality_gate_status` for brevity

## Test plan
- [x] All existing tests pass
- [x] CI checks pass (formatting, linting, type checking, build)
- [x] Test coverage maintained at 93.86%

🤖 Generated with [Claude Code](https://claude.ai/code)