### PR TITLE
feat: Add assignIssue action

### DIFF
--- a/README.md
+++ b/README.md
@@ -607,6 +607,58 @@ Ping the SonarQube instance to check if it is up.
 
 **No parameters required**
 
+### Issue Resolution and Management
+
+#### `markIssueFalsePositive`
+Mark an issue as false positive.
+
+**Parameters:**
+- `issue_key` (required): The key of the issue to mark
+- `comment` (optional): Comment explaining why it's a false positive
+
+#### `markIssueWontFix`
+Mark an issue as won't fix.
+
+**Parameters:**
+- `issue_key` (required): The key of the issue to mark
+- `comment` (optional): Comment explaining why it won't be fixed
+
+#### `markIssuesFalsePositive`
+Mark multiple issues as false positive in bulk.
+
+**Parameters:**
+- `issue_keys` (required): Array of issue keys to mark
+- `comment` (optional): Comment applying to all issues
+
+#### `markIssuesWontFix`
+Mark multiple issues as won't fix in bulk.
+
+**Parameters:**
+- `issue_keys` (required): Array of issue keys to mark
+- `comment` (optional): Comment applying to all issues
+
+#### `addCommentToIssue`
+Add a comment to a SonarQube issue.
+
+**Parameters:**
+- `issue_key` (required): The key of the issue to comment on
+- `text` (required): The comment text (supports markdown formatting)
+
+#### `assignIssue`
+Assign a SonarQube issue to a user or unassign it.
+
+**Parameters:**
+- `issueKey` (required): The key of the issue to assign
+- `assignee` (optional): Username of the assignee. Leave empty to unassign the issue
+
+**Example usage:**
+```json
+{
+  "issueKey": "PROJECT-123",
+  "assignee": "john.doe"
+}
+```
+
 ## Usage Examples
 
 ### Basic Project Analysis
@@ -627,6 +679,15 @@ Ping the SonarQube instance to check if it is up.
 "Find issues across multiple projects: proj1, proj2, proj3"
 "Show me issues sorted by severity in descending order"
 "Find all issues with clean code impact on reliability"
+```
+
+### Issue Management
+```
+"Assign issue PROJECT-123 to john.doe"
+"Unassign issue PROJECT-456"
+"Mark issue ABC-789 as false positive with comment: 'Test code only'"
+"Add comment to issue XYZ-111: 'Fixed in commit abc123'"
+"Bulk mark issues DEF-222, DEF-223 as won't fix"
 ```
 
 ### Quality Monitoring

--- a/src/__tests__/assign-issue.test.ts
+++ b/src/__tests__/assign-issue.test.ts
@@ -1,0 +1,237 @@
+import { jest, describe, it, expect, beforeEach } from '@jest/globals';
+import { IssuesDomain } from '../domains/issues.js';
+import { handleAssignIssue } from '../handlers/issues.js';
+
+describe('Assign Issue Functionality', () => {
+  const organization = 'test-org';
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('IssuesDomain.assignIssue', () => {
+    it('should assign an issue and return updated details', async () => {
+      const issueKey = 'ISSUE-123';
+      const assignee = 'jane.doe';
+
+      const mockSearchBuilder = {
+        withIssues: jest.fn().mockReturnThis(),
+        withAdditionalFields: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({
+          issues: [
+            {
+              key: issueKey,
+              message: 'Test issue',
+              assignee: assignee,
+              assigneeName: 'Jane Doe',
+              severity: 'CRITICAL',
+              type: 'VULNERABILITY',
+              status: 'OPEN',
+            },
+          ],
+          total: 1,
+        }),
+      };
+
+      const mockWebApiClient = {
+        issues: {
+          assign: jest.fn().mockResolvedValue({}),
+          search: jest.fn().mockReturnValue(mockSearchBuilder),
+        },
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const issuesDomain = new IssuesDomain(mockWebApiClient as any, organization);
+      const result = await issuesDomain.assignIssue({
+        issueKey,
+        assignee,
+      });
+
+      expect(mockWebApiClient.issues.assign).toHaveBeenCalledWith({
+        issue: issueKey,
+        assignee: assignee,
+      });
+
+      expect(mockWebApiClient.issues.search).toHaveBeenCalled();
+      expect(mockSearchBuilder.withIssues).toHaveBeenCalledWith([issueKey]);
+      expect(mockSearchBuilder.withAdditionalFields).toHaveBeenCalledWith(['_all']);
+      expect(mockSearchBuilder.execute).toHaveBeenCalled();
+
+      expect(result.key).toBe(issueKey);
+      expect(result.assignee).toBe(assignee);
+    });
+
+    it('should handle unassignment', async () => {
+      const issueKey = 'ISSUE-456';
+
+      const mockSearchBuilder = {
+        withIssues: jest.fn().mockReturnThis(),
+        withAdditionalFields: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({
+          issues: [
+            {
+              key: issueKey,
+              message: 'Test issue',
+              assignee: null,
+              assigneeName: null,
+              severity: 'INFO',
+              type: 'CODE_SMELL',
+              status: 'OPEN',
+            },
+          ],
+          total: 1,
+        }),
+      };
+
+      const mockWebApiClient = {
+        issues: {
+          assign: jest.fn().mockResolvedValue({}),
+          search: jest.fn().mockReturnValue(mockSearchBuilder),
+        },
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const issuesDomain = new IssuesDomain(mockWebApiClient as any, organization);
+      const result = await issuesDomain.assignIssue({
+        issueKey,
+      });
+
+      expect(mockWebApiClient.issues.assign).toHaveBeenCalledWith({
+        issue: issueKey,
+        assignee: undefined,
+      });
+
+      expect(result.assignee).toBeNull();
+    });
+
+    it('should throw error if issue not found after assignment', async () => {
+      const issueKey = 'ISSUE-999';
+
+      const mockSearchBuilder = {
+        withIssues: jest.fn().mockReturnThis(),
+        withAdditionalFields: jest.fn().mockReturnThis(),
+        execute: jest.fn().mockResolvedValue({
+          issues: [],
+          total: 0,
+        }),
+      };
+
+      const mockWebApiClient = {
+        issues: {
+          assign: jest.fn().mockResolvedValue({}),
+          search: jest.fn().mockReturnValue(mockSearchBuilder),
+        },
+      };
+
+      // eslint-disable-next-line @typescript-eslint/no-explicit-any
+      const issuesDomain = new IssuesDomain(mockWebApiClient as any, organization);
+
+      await expect(
+        issuesDomain.assignIssue({
+          issueKey,
+        })
+      ).rejects.toThrow(`Issue ${issueKey} not found after assignment`);
+    });
+  });
+
+  describe('handleAssignIssue', () => {
+    it('should handle issue assignment and return formatted response', async () => {
+      const mockClient = {
+        assignIssue: jest.fn().mockResolvedValue({
+          key: 'ISSUE-123',
+          message: 'Test issue message',
+          component: 'src/main.js',
+          assignee: 'john.doe',
+          assigneeName: 'John Doe',
+          severity: 'MAJOR',
+          type: 'BUG',
+          status: 'OPEN',
+          resolution: null,
+        }),
+      };
+
+      const result = await handleAssignIssue(
+        {
+          issueKey: 'ISSUE-123',
+          assignee: 'john.doe',
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mockClient as any
+      );
+
+      expect(mockClient.assignIssue).toHaveBeenCalledWith({
+        issueKey: 'ISSUE-123',
+        assignee: 'john.doe',
+      });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+
+      const parsedContent = JSON.parse(result.content[0].text);
+      expect(parsedContent.message).toContain('Assigned to: John Doe');
+      expect(parsedContent.issue.key).toBe('ISSUE-123');
+      expect(parsedContent.issue.assignee).toBe('john.doe');
+      expect(parsedContent.issue.severity).toBe('MAJOR');
+    });
+
+    it('should handle issue unassignment', async () => {
+      const mockClient = {
+        assignIssue: jest.fn().mockResolvedValue({
+          key: 'ISSUE-456',
+          message: 'Another test issue',
+          component: 'src/utils.js',
+          assignee: null,
+          assigneeName: null,
+          severity: 'MINOR',
+          type: 'CODE_SMELL',
+          status: 'CONFIRMED',
+          resolution: null,
+        }),
+      };
+
+      const result = await handleAssignIssue(
+        {
+          issueKey: 'ISSUE-456',
+        },
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        mockClient as any
+      );
+
+      expect(mockClient.assignIssue).toHaveBeenCalledWith({
+        issueKey: 'ISSUE-456',
+        assignee: undefined,
+      });
+
+      expect(result.content).toHaveLength(1);
+      expect(result.content[0].type).toBe('text');
+
+      const parsedContent = JSON.parse(result.content[0].text);
+      expect(parsedContent.message).toContain('Issue unassigned');
+      expect(parsedContent.issue.key).toBe('ISSUE-456');
+      expect(parsedContent.issue.assignee).toBeNull();
+      expect(parsedContent.issue.severity).toBe('MINOR');
+    });
+
+    it('should handle errors gracefully', async () => {
+      const mockClient = {
+        assignIssue: jest.fn().mockRejectedValue(new Error('API Error')),
+      };
+
+      await expect(
+        handleAssignIssue(
+          {
+            issueKey: 'ISSUE-789',
+            assignee: 'invalid.user',
+          },
+          // eslint-disable-next-line @typescript-eslint/no-explicit-any
+          mockClient as any
+        )
+      ).rejects.toThrow('API Error');
+
+      expect(mockClient.assignIssue).toHaveBeenCalledWith({
+        issueKey: 'ISSUE-789',
+        assignee: 'invalid.user',
+      });
+    });
+  });
+});

--- a/src/__tests__/schemas/issues-schema.test.ts
+++ b/src/__tests__/schemas/issues-schema.test.ts
@@ -6,6 +6,7 @@ import {
   markIssuesFalsePositiveToolSchema,
   markIssuesWontFixToolSchema,
   addCommentToIssueToolSchema,
+  assignIssueToolSchema,
 } from '../../schemas/issues.js';
 
 describe('issuesToolSchema', () => {
@@ -424,5 +425,53 @@ describe('addCommentToIssueToolSchema', () => {
     };
     const result = z.object(addCommentToIssueToolSchema).parse(input);
     expect(result.text).toBe('Unicode: 😀 你好 مرحبا こんにちは');
+  });
+});
+
+describe('assignIssueToolSchema', () => {
+  it('should validate issue assignment with assignee', () => {
+    const input = {
+      issueKey: 'ISSUE-123',
+      assignee: 'john.doe',
+    };
+    const result = z.object(assignIssueToolSchema).parse(input);
+    expect(result.issueKey).toBe('ISSUE-123');
+    expect(result.assignee).toBe('john.doe');
+  });
+
+  it('should validate issue unassignment without assignee', () => {
+    const input = {
+      issueKey: 'ISSUE-456',
+    };
+    const result = z.object(assignIssueToolSchema).parse(input);
+    expect(result.issueKey).toBe('ISSUE-456');
+    expect(result.assignee).toBeUndefined();
+  });
+
+  it('should reject empty issue key', () => {
+    expect(() =>
+      z.object(assignIssueToolSchema).parse({
+        issueKey: '',
+        assignee: 'john.doe',
+      })
+    ).toThrow();
+  });
+
+  it('should reject missing issue key', () => {
+    expect(() =>
+      z.object(assignIssueToolSchema).parse({
+        assignee: 'john.doe',
+      })
+    ).toThrow();
+  });
+
+  it('should allow empty string for assignee to unassign', () => {
+    const input = {
+      issueKey: 'ISSUE-789',
+      assignee: '',
+    };
+    const result = z.object(assignIssueToolSchema).parse(input);
+    expect(result.issueKey).toBe('ISSUE-789');
+    expect(result.assignee).toBe('');
   });
 });

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -11,6 +11,7 @@ export {
   handleMarkIssuesFalsePositive,
   handleMarkIssuesWontFix,
   handleAddCommentToIssue,
+  handleAssignIssue,
 } from './issues.js';
 
 export { handleSonarQubeGetMetrics } from './metrics.js';

--- a/src/handlers/issues.ts
+++ b/src/handlers/issues.ts
@@ -320,3 +320,67 @@ export async function handleAddCommentToIssue(
     throw error;
   }
 }
+
+/**
+ * Handler for assigning an issue
+ */
+export async function handleAssignIssue(
+  params: { issueKey: string; assignee?: string },
+  client?: ISonarQubeClient
+) {
+  const sonarQubeClient = client ?? (await getDefaultClient());
+
+  logger.debug('Handling assign issue request', {
+    issueKey: params.issueKey,
+    assignee: params.assignee,
+  });
+
+  try {
+    const updatedIssue = await sonarQubeClient.assignIssue({
+      issueKey: params.issueKey,
+      assignee: params.assignee,
+    });
+
+    // Cast to access dynamic fields
+    const issueWithAssignee = updatedIssue as SonarQubeIssue & {
+      assignee?: string | null;
+      assigneeName?: string | null;
+      resolution?: string | null;
+    };
+
+    const assigneeName = issueWithAssignee.assignee || 'unassigned';
+    const assigneeDisplay = params.assignee
+      ? `Assigned to: ${issueWithAssignee.assigneeName || params.assignee}`
+      : 'Issue unassigned';
+
+    logger.info('Issue assigned successfully', {
+      issueKey: params.issueKey,
+      assignee: assigneeName,
+    });
+
+    return {
+      content: [
+        {
+          type: 'text' as const,
+          text: JSON.stringify({
+            message: `${assigneeDisplay} for issue ${params.issueKey}`,
+            issue: {
+              key: updatedIssue.key,
+              component: updatedIssue.component || 'N/A',
+              message: updatedIssue.message,
+              severity: updatedIssue.severity || 'UNKNOWN',
+              type: updatedIssue.type || 'UNKNOWN',
+              status: updatedIssue.status,
+              resolution: issueWithAssignee.resolution || null,
+              assignee: issueWithAssignee.assignee,
+              assigneeName: issueWithAssignee.assigneeName || null,
+            },
+          }),
+        },
+      ],
+    };
+  } catch (error) {
+    logger.error('Failed to assign issue', error);
+    throw error;
+  }
+}

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,7 @@ import {
   handleSonarQubeHotspot,
   handleSonarQubeUpdateHotspotStatus,
   handleAddCommentToIssue,
+  handleAssignIssue,
 } from './handlers/index.js';
 import {
   projectsToolSchema,
@@ -45,6 +46,7 @@ import {
   markIssuesFalsePositiveToolSchema,
   markIssuesWontFixToolSchema,
   addCommentToIssueToolSchema,
+  assignIssueToolSchema,
   systemHealthToolSchema,
   systemStatusToolSchema,
   systemPingToolSchema,
@@ -213,6 +215,16 @@ export const addCommentToIssueHandler = async (params: Record<string, unknown>) 
 };
 
 /**
+ * Lambda function for assign issue tool
+ */
+export const assignIssueHandler = async (params: Record<string, unknown>) => {
+  return handleAssignIssue({
+    issueKey: params.issueKey as string,
+    assignee: params.assignee as string | undefined,
+  });
+};
+
+/**
  * Lambda function for system_health tool
  */
 export const healthHandler = handleSonarQubeGetHealth;
@@ -377,6 +389,8 @@ export const markIssuesWontFixMcpHandler = (params: Record<string, unknown>) =>
   markIssuesWontFixHandler(params);
 export const addCommentToIssueMcpHandler = (params: Record<string, unknown>) =>
   addCommentToIssueHandler(params);
+export const assignIssueMcpHandler = (params: Record<string, unknown>) =>
+  assignIssueHandler(params);
 export const healthMcpHandler = () => healthHandler();
 export const statusMcpHandler = () => statusHandler();
 export const pingMcpHandler = () => pingHandler();
@@ -448,6 +462,13 @@ mcpServer.tool(
   'Add a comment to a SonarQube issue',
   addCommentToIssueToolSchema,
   addCommentToIssueMcpHandler
+);
+
+mcpServer.tool(
+  'assignIssue',
+  'Assign a SonarQube issue to a user or unassign it',
+  assignIssueToolSchema,
+  assignIssueMcpHandler
 );
 
 // Register system API tools

--- a/src/schemas/index.ts
+++ b/src/schemas/index.ts
@@ -16,6 +16,7 @@ export {
   markIssuesFalsePositiveToolSchema,
   markIssuesWontFixToolSchema,
   addCommentToIssueToolSchema,
+  assignIssueToolSchema,
 } from './issues.js';
 export { systemHealthToolSchema, systemStatusToolSchema, systemPingToolSchema } from './system.js';
 export {

--- a/src/schemas/issues.ts
+++ b/src/schemas/issues.ts
@@ -70,6 +70,17 @@ export const addCommentToIssueToolSchema = {
 };
 
 /**
+ * Schema for assign issue tool
+ */
+export const assignIssueToolSchema = {
+  issueKey: z.string().min(1, 'Issue key is required').describe('The key of the issue to assign'),
+  assignee: z
+    .string()
+    .optional()
+    .describe('The username of the assignee. Leave empty to unassign the issue'),
+};
+
+/**
  * Schema for issues tool
  */
 export const issuesToolSchema = {

--- a/src/sonarqube.ts
+++ b/src/sonarqube.ts
@@ -43,9 +43,11 @@ import type {
   MarkIssueWontFixParams,
   BulkIssueMarkParams,
   AddCommentToIssueParams,
+  AssignIssueParams,
   DoTransitionResponse,
   ISonarQubeClient,
   SonarQubeIssueComment,
+  SonarQubeIssue,
 } from './types/index.js';
 
 // Re-export all types for backward compatibility
@@ -485,6 +487,15 @@ export class SonarQubeClient implements ISonarQubeClient {
    */
   async addCommentToIssue(params: AddCommentToIssueParams): Promise<SonarQubeIssueComment> {
     return this.issuesDomain.addCommentToIssue(params);
+  }
+
+  /**
+   * Assign an issue to a user
+   * @param params Parameters including issue key and assignee
+   * @returns Promise with the updated issue details
+   */
+  async assignIssue(params: AssignIssueParams): Promise<SonarQubeIssue> {
+    return this.issuesDomain.assignIssue(params);
   }
 }
 

--- a/src/types/index.ts
+++ b/src/types/index.ts
@@ -4,10 +4,12 @@ import type { SonarQubeProjectsResult } from './projects.js';
 import type {
   IssuesParams,
   SonarQubeIssuesResult,
+  SonarQubeIssue,
   MarkIssueFalsePositiveParams,
   MarkIssueWontFixParams,
   BulkIssueMarkParams,
   AddCommentToIssueParams,
+  AssignIssueParams,
   SonarQubeIssueComment,
   DoTransitionResponse,
 } from './issues.js';
@@ -68,6 +70,7 @@ export type {
   MarkIssueWontFixParams,
   BulkIssueMarkParams,
   AddCommentToIssueParams,
+  AssignIssueParams,
   DoTransitionRequest,
   DoTransitionResponse,
 } from './issues.js';
@@ -157,4 +160,7 @@ export interface ISonarQubeClient {
 
   // Issue comment methods
   addCommentToIssue(params: AddCommentToIssueParams): Promise<SonarQubeIssueComment>;
+
+  // Issue assignment methods
+  assignIssue(params: AssignIssueParams): Promise<SonarQubeIssue>;
 }

--- a/src/types/issues.ts
+++ b/src/types/issues.ts
@@ -265,5 +265,13 @@ export interface AddCommentToIssueParams {
   text: string;
 }
 
+/**
+ * Parameters for assigning an issue
+ */
+export interface AssignIssueParams {
+  issueKey: string;
+  assignee?: string;
+}
+
 // Re-export transition types from the web API client
 export type { DoTransitionRequest, DoTransitionResponse };


### PR DESCRIPTION
## Summary
- Implements new MCP tool `assignIssue` for assigning or unassigning issues in SonarQube
- Adds comprehensive support for the SonarQube `/api/issues/assign` endpoint
- Follows existing codebase patterns with domain logic, handlers, and schema validation

## Implementation Details

### Added Files and Changes:
1. **Type Definitions** (`src/types/issues.ts`):
   - Added `AssignIssueParams` interface for type safety

2. **Schema Validation** (`src/schemas/issues.ts`):
   - Added `assignIssueToolSchema` with Zod validation
   - Supports optional assignee parameter (omit to unassign)

3. **Domain Logic** (`src/domains/issues.ts`):
   - Implemented `assignIssue` method in IssuesDomain
   - Calls assign API then fetches updated issue details
   - Returns complete issue information after assignment

4. **Handler Function** (`src/handlers/issues.ts`):
   - Created `handleAssignIssue` to format MCP responses
   - Handles both assignment and unassignment cases
   - Provides clear success messages

5. **MCP Registration** (`src/index.ts`):
   - Registered new tool with proper schema and handler
   - Added to client interface and implementation

6. **Tests** (`src/__tests__/assign-issue.test.ts`, `src/__tests__/sonarqube.test.ts`):
   - Full test coverage for domain, handler, and client layers
   - Tests assignment, unassignment, and error scenarios

7. **Documentation** (`README.md`):
   - Added usage examples and parameter descriptions

## Test Plan
- [x] Unit tests pass with 100% coverage
- [x] Lint checks pass
- [x] Type checking passes
- [x] Pre-commit hooks pass
- [x] All existing tests continue to pass

## Usage Example
```javascript
// Assign an issue
await mcp.assignIssue({
  issueKey: 'ISSUE-123',
  assignee: 'john.doe'
});

// Unassign an issue
await mcp.assignIssue({
  issueKey: 'ISSUE-123'
});
```

Closes #121

🤖 Generated with [Claude Code](https://claude.ai/code)