### PR TITLE
chore: Update sonarqube-web-api-client to 0.11.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -59,7 +59,7 @@
     "@modelcontextprotocol/sdk": "^1.12.1",
     "cors": "^2.8.5",
     "express": "^5.1.0",
-    "sonarqube-web-api-client": "0.10.1",
+    "sonarqube-web-api-client": "0.11.0",
     "zod": "^3.25.63"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -22,8 +22,8 @@ importers:
         specifier: ^5.1.0
         version: 5.1.0
       sonarqube-web-api-client:
-        specifier: 0.10.1
-        version: 0.10.1
+        specifier: 0.11.0
+        version: 0.11.0
       zod:
         specifier: ^3.25.63
         version: 3.25.63
@@ -2221,8 +2221,8 @@ packages:
     resolution: {integrity: sha512-bSiSngZ/jWeX93BqeIAbImyTbEihizcwNjFoRUIY/T1wWQsfsm2Vw1agPKylXvQTU7iASGdHhyqRlqQzfz+Htg==}
     engines: {node: '>=18'}
 
-  sonarqube-web-api-client@0.10.1:
-    resolution: {integrity: sha512-h+ecjMQHVk1TAW5voCcfqMFKmIxNkAMCxlZZK+G2byv8p1o1xMFdF9rN3zan8qm8uxJTxg2vyPg3YLADqN4pBg==}
+  sonarqube-web-api-client@0.11.0:
+    resolution: {integrity: sha512-/75CuyKgZW3dpBuqG/EYE/aF7ROTF5/GxCvoegZ91FNfiTxECsHo75TFqV0SV3e9Yc3/aF04tF/0Z+gMT9WcVA==}
 
   source-map-support@0.5.13:
     resolution: {integrity: sha512-SHSKFHadjVA5oR4PPqhtAVdcBWwRYVd6g6cAXnIbRiIwc2EhPrTuKUBdSLvlEKyIP3GCf89fltvcZiP9MMFA1w==}
@@ -5012,7 +5012,7 @@ snapshots:
       ansi-styles: 6.2.1
       is-fullwidth-code-point: 5.0.0
 
-  sonarqube-web-api-client@0.10.1: {}
+  sonarqube-web-api-client@0.11.0: {}
 
   source-map-support@0.5.13:
     dependencies:


### PR DESCRIPTION
## Summary
- Updated sonarqube-web-api-client from 0.10.1 to 0.11.0
- Version 0.11.0 includes enhanced Issues Search API with directory/file/scope filtering
- No breaking changes identified

## Test plan
- [x] Updated dependency version in package.json
- [x] Ran `pnpm install` to update lock file
- [x] All TypeScript type checks pass (`pnpm run check-types`)
- [x] All linting checks pass (`pnpm run lint`)
- [x] All tests pass (582 tests)
- [x] Full CI pipeline passes (`pnpm run ci`)

🤖 Generated with [Claude Code](https://claude.ai/code)