### PR TITLE
feat: Add directory, file, and scope filtering to issues search

### DIFF
--- a/src/__tests__/issues-new-parameters.test.ts
+++ b/src/__tests__/issues-new-parameters.test.ts
@@ -1,0 +1,291 @@
+/// <reference types="jest" />
+
+/**
+ * @jest-environment node
+ */
+
+import { describe, it, expect, beforeEach, jest } from '@jest/globals';
+import type { SearchIssuesRequestBuilderInterface } from 'sonarqube-web-api-client';
+
+// Mock environment variables
+process.env.SONARQUBE_TOKEN = 'test-token';
+process.env.SONARQUBE_URL = 'http://localhost:9000';
+process.env.SONARQUBE_ORGANIZATION = 'test-org';
+
+// Mock search builder
+const mockSearchBuilder = {
+  withProjects: jest.fn().mockReturnThis(),
+  withComponents: jest.fn().mockReturnThis(),
+  withDirectories: jest.fn().mockReturnThis(),
+  withFiles: jest.fn().mockReturnThis(),
+  withScopes: jest.fn().mockReturnThis(),
+  onComponentOnly: jest.fn().mockReturnThis(),
+  onBranch: jest.fn().mockReturnThis(),
+  onPullRequest: jest.fn().mockReturnThis(),
+  withIssues: jest.fn().mockReturnThis(),
+  withSeverities: jest.fn().mockReturnThis(),
+  withStatuses: jest.fn().mockReturnThis(),
+  withResolutions: jest.fn().mockReturnThis(),
+  onlyResolved: jest.fn().mockReturnThis(),
+  onlyUnresolved: jest.fn().mockReturnThis(),
+  withTypes: jest.fn().mockReturnThis(),
+  withCleanCodeAttributeCategories: jest.fn().mockReturnThis(),
+  withImpactSeverities: jest.fn().mockReturnThis(),
+  withImpactSoftwareQualities: jest.fn().mockReturnThis(),
+  withIssueStatuses: jest.fn().mockReturnThis(),
+  withRules: jest.fn().mockReturnThis(),
+  withTags: jest.fn().mockReturnThis(),
+  createdAfter: jest.fn().mockReturnThis(),
+  createdBefore: jest.fn().mockReturnThis(),
+  createdAt: jest.fn().mockReturnThis(),
+  createdInLast: jest.fn().mockReturnThis(),
+  onlyAssigned: jest.fn().mockReturnThis(),
+  onlyUnassigned: jest.fn().mockReturnThis(),
+  assignedToAny: jest.fn().mockReturnThis(),
+  byAuthor: jest.fn().mockReturnThis(),
+  byAuthors: jest.fn().mockReturnThis(),
+  withCwe: jest.fn().mockReturnThis(),
+  withOwaspTop10: jest.fn().mockReturnThis(),
+  withOwaspTop10v2021: jest.fn().mockReturnThis(),
+  withSansTop25: jest.fn().mockReturnThis(),
+  withSonarSourceSecurity: jest.fn().mockReturnThis(),
+  withSonarSourceSecurityNew: jest.fn().mockReturnThis(),
+  withLanguages: jest.fn().mockReturnThis(),
+  withFacets: jest.fn().mockReturnThis(),
+  withFacetMode: jest.fn().mockReturnThis(),
+  sinceLeakPeriod: jest.fn().mockReturnThis(),
+  inNewCodePeriod: jest.fn().mockReturnThis(),
+  sortBy: jest.fn().mockReturnThis(),
+  withAdditionalFields: jest.fn().mockReturnThis(),
+  page: jest.fn().mockReturnThis(),
+  pageSize: jest.fn().mockReturnThis(),
+  execute: jest.fn(),
+} as unknown as SearchIssuesRequestBuilderInterface;
+
+// Mock the web API client
+jest.mock('sonarqube-web-api-client', () => ({
+  SonarQubeClient: {
+    withToken: jest.fn().mockReturnValue({
+      issues: {
+        search: jest.fn().mockReturnValue(mockSearchBuilder),
+      },
+    }),
+  },
+}));
+
+import { IssuesDomain } from '../domains/issues.js';
+import type { IssuesParams, IWebApiClient } from '../types/index.js';
+
+describe('IssuesDomain new parameters', () => {
+  let issuesDomain: IssuesDomain;
+
+  beforeEach(() => {
+    // Reset all mocks
+    jest.clearAllMocks();
+
+    // Reset execute mock to return default response
+    mockSearchBuilder.execute.mockResolvedValue({
+      issues: [],
+      components: [],
+      rules: [],
+      paging: { pageIndex: 1, pageSize: 100, total: 0 },
+    });
+
+    // Create mock web API client
+    const mockWebApiClient = {
+      issues: {
+        search: jest.fn().mockReturnValue(mockSearchBuilder),
+      },
+    } as unknown as IWebApiClient;
+
+    // Create issues domain instance
+    issuesDomain = new IssuesDomain(mockWebApiClient);
+  });
+
+  describe('directories parameter', () => {
+    it('should call withDirectories when directories parameter is provided', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+        directories: ['src/main/', 'src/test/'],
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withDirectories).toHaveBeenCalledWith(['src/main/', 'src/test/']);
+      expect(mockSearchBuilder.withDirectories).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call withDirectories when directories parameter is not provided', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withDirectories).not.toHaveBeenCalled();
+    });
+
+    it('should handle empty directories array', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+        directories: [],
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withDirectories).toHaveBeenCalledWith([]);
+    });
+  });
+
+  describe('files parameter', () => {
+    it('should call withFiles when files parameter is provided', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+        files: ['UserService.java', 'config.properties'],
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withFiles).toHaveBeenCalledWith([
+        'UserService.java',
+        'config.properties',
+      ]);
+      expect(mockSearchBuilder.withFiles).toHaveBeenCalledTimes(1);
+    });
+
+    it('should not call withFiles when files parameter is not provided', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withFiles).not.toHaveBeenCalled();
+    });
+
+    it('should handle single file', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+        files: ['App.java'],
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withFiles).toHaveBeenCalledWith(['App.java']);
+    });
+  });
+
+  describe('scopes parameter', () => {
+    it('should call withScopes when scopes parameter is provided', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+        scopes: ['MAIN', 'TEST'],
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withScopes).toHaveBeenCalledWith(['MAIN', 'TEST']);
+      expect(mockSearchBuilder.withScopes).toHaveBeenCalledTimes(1);
+    });
+
+    it('should handle single scope value', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+        scopes: ['MAIN'],
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withScopes).toHaveBeenCalledWith(['MAIN']);
+    });
+
+    it('should handle all scope values', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+        scopes: ['MAIN', 'TEST', 'OVERALL'],
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withScopes).toHaveBeenCalledWith(['MAIN', 'TEST', 'OVERALL']);
+    });
+
+    it('should not call withScopes when scopes parameter is not provided', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withScopes).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('combined parameters', () => {
+    it('should handle all three new parameters together', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+        directories: ['src/main/java/', 'src/test/java/'],
+        files: ['Application.java', 'pom.xml'],
+        scopes: ['MAIN', 'TEST', 'OVERALL'],
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withDirectories).toHaveBeenCalledWith([
+        'src/main/java/',
+        'src/test/java/',
+      ]);
+      expect(mockSearchBuilder.withFiles).toHaveBeenCalledWith(['Application.java', 'pom.xml']);
+      expect(mockSearchBuilder.withScopes).toHaveBeenCalledWith(['MAIN', 'TEST', 'OVERALL']);
+    });
+
+    it('should work with existing component filters', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+        componentKeys: ['src/main/java/com/example/Service.java'],
+        directories: ['src/main/java/com/example/'],
+        files: ['Service.java'],
+        scopes: ['MAIN'],
+      };
+
+      await issuesDomain.getIssues(params);
+
+      expect(mockSearchBuilder.withComponents).toHaveBeenCalledWith([
+        'src/main/java/com/example/Service.java',
+      ]);
+      expect(mockSearchBuilder.withDirectories).toHaveBeenCalledWith([
+        'src/main/java/com/example/',
+      ]);
+      expect(mockSearchBuilder.withFiles).toHaveBeenCalledWith(['Service.java']);
+      expect(mockSearchBuilder.withScopes).toHaveBeenCalledWith(['MAIN']);
+    });
+
+    it('should work with all filtering types together', async () => {
+      const params: IssuesParams = {
+        projectKey: 'test-project',
+        componentKeys: ['src/Service.java'],
+        directories: ['src/'],
+        files: ['Service.java', 'Controller.java'],
+        scopes: ['MAIN'],
+        severities: ['CRITICAL', 'BLOCKER'],
+        statuses: ['OPEN'],
+        tags: ['security'],
+      };
+
+      await issuesDomain.getIssues(params);
+
+      // Component filters
+      expect(mockSearchBuilder.withProjects).toHaveBeenCalledWith(['test-project']);
+      expect(mockSearchBuilder.withComponents).toHaveBeenCalledWith(['src/Service.java']);
+      expect(mockSearchBuilder.withDirectories).toHaveBeenCalledWith(['src/']);
+      expect(mockSearchBuilder.withFiles).toHaveBeenCalledWith(['Service.java', 'Controller.java']);
+      expect(mockSearchBuilder.withScopes).toHaveBeenCalledWith(['MAIN']);
+
+      // Issue filters
+      expect(mockSearchBuilder.withSeverities).toHaveBeenCalledWith(['CRITICAL', 'BLOCKER']);
+      expect(mockSearchBuilder.withStatuses).toHaveBeenCalledWith(['OPEN']);
+      expect(mockSearchBuilder.withTags).toHaveBeenCalledWith(['security']);
+    });
+  });
+});

--- a/src/domains/issues.ts
+++ b/src/domains/issues.ts
@@ -82,6 +82,15 @@ export class IssuesDomain extends BaseDomain {
     if (params.onComponentOnly) {
       builder.onComponentOnly();
     }
+    if (params.directories) {
+      builder.withDirectories(params.directories);
+    }
+    if (params.files) {
+      builder.withFiles(params.files);
+    }
+    if (params.scopes) {
+      builder.withScopes(params.scopes);
+    }
 
     // Branch and PR
     if (params.branch) {

--- a/src/handlers/issues.ts
+++ b/src/handlers/issues.ts
@@ -21,6 +21,9 @@ const logger = createLogger('handlers/issues');
  *
  * This tool supports comprehensive filtering for targeted analysis, dashboards, and audits:
  * - **Component/File Path Filtering**: Use `component_keys` to filter by specific files or directories
+ * - **Directory Filtering**: Use `directories` to filter by directory paths (e.g., ['src/main/', 'test/'])
+ * - **File Filtering**: Use `files` to filter by specific file paths (e.g., ['UserService.java', 'config.properties'])
+ * - **Scope Filtering**: Use `scopes` to filter by issue scope (MAIN for production code, TEST for test code, OVERALL for both)
  * - **Assignee Filtering**: Use `assignees` to filter by assigned users
  * - **Tag Filtering**: Use `tags` to filter by issue tags
  * - **Severity Filtering**: Use `severities` to filter by severity levels (INFO, MINOR, MAJOR, CRITICAL, BLOCKER)
@@ -41,6 +44,15 @@ const logger = createLogger('handlers/issues');
  *   componentKeys: ['src/main/java/com/example/Service.java'],
  *   severities: ['CRITICAL', 'BLOCKER'],
  *   facets: ['severities', 'types', 'authors']
+ * });
+ *
+ * @example
+ * // Filter by directory and scope
+ * await handleSonarQubeGetIssues({
+ *   projectKey: 'my-project',
+ *   directories: ['src/main/java/com/example/services/'],
+ *   scopes: ['MAIN'],
+ *   facets: ['severities', 'rules']
  * });
  *
  * @example

--- a/src/index.ts
+++ b/src/index.ts
@@ -480,7 +480,7 @@ mcpServer.tool(
 
 mcpServer.tool(
   'issues',
-  'Search and filter SonarQube issues by severity, status, assignee, tag, file path, and more. Critical for dashboards, targeted clean-up sprints, security audits, and regression testing. Supports faceted search for aggregations.',
+  'Search and filter SonarQube issues by severity, status, assignee, tag, file path, directory, scope, and more. Critical for dashboards, targeted clean-up sprints, security audits, and regression testing. Supports faceted search for aggregations.',
   issuesToolSchema,
   issuesMcpHandler
 );

--- a/src/schemas/issues.ts
+++ b/src/schemas/issues.ts
@@ -145,6 +145,13 @@ export const issuesToolSchema = {
     .nullable()
     .optional()
     .describe('Return only issues on the specified components, not on their sub-components'),
+  directories: z.array(z.string()).nullable().optional().describe('Filter by directory paths'),
+  files: z.array(z.string()).nullable().optional().describe('Filter by specific file paths'),
+  scopes: z
+    .array(z.enum(['MAIN', 'TEST', 'OVERALL']))
+    .nullable()
+    .optional()
+    .describe('Filter by issue scopes (MAIN, TEST, OVERALL)'),
 
   // Branch and PR support
   branch: z.string().nullable().optional(),

--- a/src/types/issues.ts
+++ b/src/types/issues.ts
@@ -167,6 +167,9 @@ export interface IssuesParams extends PaginationParams {
   components?: string[];
   projects?: string[];
   onComponentOnly?: boolean;
+  directories?: string[];
+  files?: string[];
+  scopes?: ('MAIN' | 'TEST' | 'OVERALL')[];
 
   // Branch and PR
   branch?: string;

--- a/src/utils/parameter-mappers.ts
+++ b/src/utils/parameter-mappers.ts
@@ -14,6 +14,9 @@ export function mapToSonarQubeParams(params: Record<string, unknown>): IssuesPar
     componentKeys: nullToUndefined(params.component_keys) as string[] | undefined,
     components: nullToUndefined(params.components) as string[] | undefined,
     onComponentOnly: nullToUndefined(params.on_component_only) as boolean | undefined,
+    directories: nullToUndefined(params.directories) as string[] | undefined,
+    files: nullToUndefined(params.files) as string[] | undefined,
+    scopes: nullToUndefined(params.scopes) as IssuesParams['scopes'],
 
     // Branch and PR support
     branch: nullToUndefined(params.branch) as string | undefined,


### PR DESCRIPTION
## Summary
- Adds support for filtering issues by directories (e.g., `src/main/`, `src/test/`)
- Adds support for filtering issues by specific files (e.g., `UserService.java`, `config.properties`)
- Adds support for filtering issues by scope (MAIN for production code, TEST for test code, OVERALL for both)

## Details
This PR leverages the new filtering capabilities introduced in sonarqube-web-api-client v0.11.0. The implementation adds three new optional parameters to the issues search:

### New Parameters:
- `directories`: Array of directory paths to filter issues
- `files`: Array of specific file names to filter issues  
- `scopes`: Array of scope values (MAIN, TEST, OVERALL) to separate production and test code issues

### Changes:
- Updated TypeScript types to include the new parameters
- Updated Zod schemas with proper validation and descriptions
- Modified the issues domain to apply the new filters using the API client methods
- Updated parameter mappers to handle the new fields
- Enhanced documentation and tool descriptions
- Added comprehensive test coverage for all new functionality

## Test plan
- [x] All existing tests pass
- [x] New test file `issues-new-parameters.test.ts` covers all new functionality
- [x] CI checks pass (format, lint, type check, tests)
- [x] Code coverage maintained at 97%+

## Usage Examples
```typescript
// Filter issues by directory
await issuesHandler({
  project_key: 'my-project',
  directories: ['src/main/java/com/example/services/'],
  scopes: ['MAIN']
});

// Filter issues by specific files
await issuesHandler({
  project_key: 'my-project',
  files: ['UserService.java', 'AuthService.java'],
  severities: ['CRITICAL', 'BLOCKER']
});

// Separate production and test code issues
await issuesHandler({
  project_key: 'my-project',
  scopes: ['TEST'], // Only test code issues
  facets: ['severities', 'rules']
});
```

🤖 Generated with [Claude Code](https://claude.ai/code)