### PR TITLE
chore: prepare release v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.5.1] - 2025-06-19
+
+### Changed
+- Updated README.md to properly document v1.5.0 release changes
+- Moved v1.4.0 updates to "Previous Updates" section in README
+
 ## [1.5.0] - 2025-06-19
 
 ### Added

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonarqube-mcp-server",
-  "version": "1.5.0",
+  "version": "1.5.1",
   "description": "Model Context Protocol server for SonarQube",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v1.5.1

This is a documentation-only patch release that updates the README.md to properly document the v1.5.0 changes.

### Changes in this release:
- Updated README.md to properly document v1.5.0 release changes
- Moved v1.4.0 updates to "Previous Updates" section in README

### Release checklist:
- [x] Version bumped in package.json
- [x] CHANGELOG.md updated
- [x] README.md reviewed and updated if needed
- [x] All tests pass locally
- [ ] CI/CD pipeline passes
- [ ] Ready to merge and create GitHub release

🤖 Generated with [Claude Code](https://claude.ai/code)