### PR TITLE
Remove Previous Updates section from README

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,20 +25,6 @@ A Model Context Protocol (MCP) server that integrates with SonarQube to provide 
 - **Admin Permission Clarification**: Clarified that the `projects` tool requires admin permissions
 - **Alternative for Non-Admins**: Added guidance to use `components` tool with project qualifier for listing accessible projects
 
-## Previous Updates (v1.4.0)
-
-### Issue Management Enhancements
-- **File and Directory Filtering**: Filter issues by specific files (`files`), directories (`directories`), or code scopes (`scopes`)
-- **Bulk Issue Actions**: Mark multiple issues as false positive or won't fix in a single operation
-- **Issue Comments**: Add comments to issues for better collaboration
-- **Issue Assignment**: Assign issues to specific users or unassign them
-- **Issue Transitions**: Confirm, unconfirm, resolve, and reopen issues with optional comments
-
-### Developer Experience Improvements
-- **Enhanced Validation**: Better error messages and input validation for all tools
-- **Improved Documentation**: Added Architecture Decision Records (ADRs) for design decisions
-- **Code Quality Standards**: New conventions in CLAUDE.md for maintaining code quality
-- **Updated Dependencies**: Upgraded to sonarqube-web-api-client 0.11.0 with deprecation warnings
 
 ## Overview
 


### PR DESCRIPTION
## Summary
- Removed the outdated Previous Updates (v1.4.0) section from README.md
- Keeps documentation focused on current features and what's new in v1.5.0
- Maintains cleaner, more concise README structure

## Test plan
- [x] README renders correctly without the Previous Updates section
- [x] All CI checks pass

🤖 Generated with [Claude Code](https://claude.ai/code)