### PR TITLE
feat: Add elicitation support for interactive user input

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,16 @@
 
 A Model Context Protocol (MCP) server that integrates with SonarQube to provide AI assistants with access to code quality metrics, issues, and analysis results.
 
-## What's New in v1.5.0
+## What's New in v1.6.0
+
+### Elicitation Support (Experimental)
+- **Interactive User Input**: Added support for MCP elicitation capability (requires MCP SDK v1.13.0+)
+- **Bulk Operation Safety**: Confirmation prompts before marking multiple issues as false positive or won't fix
+- **Context Collection**: Optional comment collection when resolving issues
+- **Authentication Assistance**: Interactive setup when credentials are missing
+- **Opt-in Feature**: Enable with `SONARQUBE_MCP_ELICITATION=true` environment variable
+
+### Previous Updates (v1.5.0)
 
 ### Component Navigation Enhancement
 - **Components Tool**: Added comprehensive search and navigation for SonarQube components (projects, directories, files)
@@ -424,6 +433,43 @@ The server supports three authentication methods, with important differences bet
 - Set `SONARQUBE_URL` to your instance URL
 - `SONARQUBE_ORGANIZATION` is typically not needed
 - All authentication methods are supported
+
+### Elicitation Configuration (Experimental)
+
+The server supports interactive user input through MCP's elicitation capability. This feature is opt-in and requires compatible MCP clients.
+
+**Environment Variables:**
+- `SONARQUBE_MCP_ELICITATION`: Set to `true` to enable elicitation
+- `SONARQUBE_MCP_BULK_THRESHOLD`: Number of items before confirmation (default: 5)
+- `SONARQUBE_MCP_REQUIRE_COMMENTS`: Set to `true` to require comments for resolutions
+- `SONARQUBE_MCP_INTERACTIVE_SEARCH`: Set to `true` for interactive disambiguation
+
+**Example Configuration:**
+```json
+{
+  "mcpServers": {
+    "sonarqube": {
+      "command": "npx",
+      "args": ["-y", "sonarqube-mcp-server@latest"],
+      "env": {
+        "SONARQUBE_URL": "https://sonarcloud.io",
+        "SONARQUBE_TOKEN": "your-token",
+        "SONARQUBE_MCP_ELICITATION": "true",
+        "SONARQUBE_MCP_BULK_THRESHOLD": "10",
+        "SONARQUBE_MCP_REQUIRE_COMMENTS": "true"
+      }
+    }
+  }
+}
+```
+
+**Features When Enabled:**
+1. **Bulk Operation Confirmation**: Prompts for confirmation before marking multiple issues
+2. **Comment Collection**: Collects explanatory comments when marking issues as false positive or won't fix
+3. **Authentication Setup**: Guides through authentication setup when credentials are missing
+4. **Search Disambiguation**: Helps select from multiple matching components or projects
+
+**Note:** This feature requires MCP clients that support elicitation. Not all clients may support this capability.
 
 ### Logging Configuration
 

--- a/doc/architecture/decisions/0012-add-elicitation-support-for-interactive-user-input.md
+++ b/doc/architecture/decisions/0012-add-elicitation-support-for-interactive-user-input.md
@@ -1,0 +1,214 @@
+# 12. Add Elicitation Support for Interactive User Input
+
+Date: 2025-06-19
+
+## Status
+
+Proposed
+
+## Context
+
+The SonarQube MCP server currently operates in a non-interactive mode, requiring all configuration and parameters to be provided upfront through environment variables or tool arguments. This approach has several limitations:
+
+1. **Bulk Operations Risk**: When performing bulk operations (e.g., marking multiple issues as false positive), there's no confirmation step, risking accidental modifications.
+
+2. **Configuration Complexity**: Users must configure authentication before starting the server, with no guidance when configuration is missing or incorrect.
+
+3. **Limited Discoverability**: Users must know exact project keys, component paths, and valid parameter values without assistance.
+
+4. **No Context Collection**: Operations like marking issues as false positive or won't fix lack the ability to collect explanatory comments interactively.
+
+MCP SDK v1.13.0 introduced the elicitation capability, which allows servers to request structured input from users through clients during operation. This feature enables:
+- Interactive data collection with JSON schema validation
+- Multi-attempt collection with confirmation
+- Type-safe input handling
+- User-controlled data sharing
+
+## Decision
+
+We will add elicitation support to the SonarQube MCP server to enable interactive user input collection in specific scenarios where it provides clear value for safety, usability, or data quality.
+
+## Implementation Plan
+
+### 1. Elicitation Use Cases
+
+#### Critical Safety Confirmations
+- **Bulk False Positive**: Confirm before marking >5 issues as false positive
+- **Bulk Won't Fix**: Confirm before marking >5 issues as won't fix
+- **Bulk Assignment**: Confirm before assigning >10 issues to a user
+
+#### Configuration Assistance
+- **Missing Authentication**: Guide users through auth setup when not configured
+- **Invalid Credentials**: Help users correct authentication issues
+- **Organization Selection**: List available organizations for SonarCloud users
+
+#### Context Collection
+- **False Positive Justification**: Collect explanation when marking issues
+- **Won't Fix Reasoning**: Document why issues won't be addressed
+- **Resolution Comments**: Gather details about how issues were resolved
+
+#### Search Refinement
+- **Component Disambiguation**: When multiple components match a query
+- **Project Selection**: When multiple projects are available
+- **Filter Refinement**: When initial search returns too many results
+
+### 2. Technical Implementation
+
+#### Schema Definitions
+```typescript
+// Confirmation schema
+const confirmationSchema = {
+  type: "object",
+  properties: {
+    confirm: { 
+      type: "boolean", 
+      description: "Confirm the operation" 
+    },
+    comment: { 
+      type: "string", 
+      description: "Optional comment",
+      maxLength: 500 
+    }
+  },
+  required: ["confirm"]
+};
+
+// Authentication schema
+const authSchema = {
+  type: "object",
+  properties: {
+    method: { 
+      type: "string", 
+      enum: ["token", "basic", "passcode"],
+      description: "Authentication method"
+    },
+    token: { 
+      type: "string",
+      description: "SonarQube token (for token auth)"
+    },
+    username: {
+      type: "string",
+      description: "Username (for basic auth)"
+    },
+    password: {
+      type: "string",
+      description: "Password (for basic auth)"
+    },
+    passcode: {
+      type: "string", 
+      description: "System passcode"
+    }
+  },
+  dependencies: {
+    method: {
+      oneOf: [
+        {
+          properties: { method: { const: "token" } },
+          required: ["token"]
+        },
+        {
+          properties: { method: { const: "basic" } },
+          required: ["username", "password"]
+        },
+        {
+          properties: { method: { const: "passcode" } },
+          required: ["passcode"]
+        }
+      ]
+    }
+  }
+};
+```
+
+#### Integration Points
+1. **Bulk Operations**: Add threshold checks and confirmation elicitation
+2. **Authentication**: Detect missing/invalid auth and offer setup assistance
+3. **Tool Enhancement**: Update existing tools to use elicitation when beneficial
+4. **Error Recovery**: Use elicitation to help users recover from common errors
+
+### 3. Configuration Options
+
+Add server options to control elicitation behavior:
+```typescript
+interface ElicitationOptions {
+  enabled: boolean;              // Master switch for elicitation
+  bulkOperationThreshold: number; // Items before confirmation (default: 5)
+  requireComments: boolean;       // Require comments for resolutions
+  interactiveSearch: boolean;     // Enable search refinement
+}
+```
+
+### 4. Backward Compatibility
+
+- Elicitation will be **opt-in** by default
+- Environment variable `SONARQUBE_MCP_ELICITATION=true` to enable
+- All existing workflows continue to work without elicitation
+- Tools detect elicitation availability and adapt behavior
+
+## Consequences
+
+### Positive
+1. **Improved Safety**: Prevents accidental bulk modifications
+2. **Better UX**: Interactive guidance for complex operations
+3. **Higher Data Quality**: Collects context and justifications
+4. **Easier Onboarding**: Helps new users configure the server
+5. **Reduced Errors**: Validates input before operations
+6. **Enhanced Discoverability**: Users learn available options interactively
+
+### Negative
+1. **SDK Dependency**: Requires upgrade to MCP SDK v1.13.0+
+2. **Increased Complexity**: More code paths to maintain
+3. **Workflow Interruption**: May slow down automated workflows
+4. **Testing Overhead**: Requires testing both interactive and non-interactive modes
+5. **Client Compatibility**: Only works with clients that support elicitation
+
+### Neutral
+1. **Optional Feature**: Can be disabled for automation scenarios
+2. **Gradual Adoption**: Can be implemented incrementally
+3. **Learning Curve**: Users need to understand when elicitation occurs
+
+## Migration Strategy
+
+### Phase 1: Foundation (Week 1)
+- Upgrade MCP SDK to v1.13.0+
+- Add elicitation configuration system
+- Create base elicitation utilities
+
+### Phase 2: Critical Safety (Week 2)
+- Implement bulk operation confirmations
+- Add tests for confirmation flows
+- Document safety features
+
+### Phase 3: Enhanced UX (Week 3-4)
+- Add authentication setup assistance
+- Implement search refinement
+- Add context collection for resolutions
+
+### Phase 4: Polish (Week 5)
+- Performance optimization
+- Extended documentation
+- User feedback incorporation
+
+## Alternatives Considered
+
+1. **Status Quo**: Continue with non-interactive operation
+   - Pros: Simple, predictable
+   - Cons: Risk of accidents, poor discoverability
+
+2. **Custom Prompting**: Use MCP prompts instead of elicitation
+   - Pros: Available in current SDK
+   - Cons: Less structured, no validation, one-way communication
+
+3. **External Configuration Tool**: Separate CLI for configuration
+   - Pros: Separation of concerns
+   - Cons: Additional tool to maintain, poor integration
+
+4. **Client-Side Validation**: Rely on clients to validate
+   - Pros: No server changes needed
+   - Cons: Inconsistent experience, no server control
+
+## References
+
+- [MCP Elicitation Specification](https://modelcontextprotocol.io/specification/2025-06-18/client/elicitation)
+- [MCP SDK v1.13.0 Release Notes](https://github.com/modelcontextprotocol/sdk/releases/tag/v1.13.0)
+- [SonarQube Web API Documentation](https://docs.sonarqube.org/latest/web-api/)

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
   "license": "MIT",
   "packageManager": "pnpm@10.7.1",
   "dependencies": {
-    "@modelcontextprotocol/sdk": "^1.12.3",
+    "@modelcontextprotocol/sdk": "^1.13.0",
     "cors": "^2.8.5",
     "express": "^5.1.0",
     "sonarqube-web-api-client": "0.11.0",
@@ -84,7 +84,8 @@
     "ts-jest": "^29.4.0",
     "ts-node": "^10.9.2",
     "ts-node-dev": "^2.0.0",
-    "typescript": "^5.8.3"
+    "typescript": "^5.8.3",
+    "zod-to-json-schema": "^3.24.5"
   },
   "pnpm": {
     "overrides": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -13,8 +13,8 @@ importers:
   .:
     dependencies:
       '@modelcontextprotocol/sdk':
-        specifier: ^1.12.3
-        version: 1.12.3
+        specifier: ^1.13.0
+        version: 1.13.0
       cors:
         specifier: ^2.8.5
         version: 2.8.5
@@ -94,6 +94,9 @@ importers:
       typescript:
         specifier: ^5.8.3
         version: 5.8.3
+      zod-to-json-schema:
+        specifier: ^3.24.5
+        version: 3.24.5(zod@3.25.64)
 
 packages:
 
@@ -464,8 +467,8 @@ packages:
   '@jridgewell/trace-mapping@0.3.9':
     resolution: {integrity: sha512-3Belt6tdc8bPgAtbcmdtNJlirVoTmEb5e2gC94PnkwEW9jI6CAHUeoG85tjWP5WquqfavoMtMwiG4P926ZKKuQ==}
 
-  '@modelcontextprotocol/sdk@1.12.3':
-    resolution: {integrity: sha512-DyVYSOafBvk3/j1Oka4z5BWT8o4AFmoNyZY9pALOm7Lh3GZglR71Co4r4dEUoqDWdDazIZQHBe7J2Nwkg6gHgQ==}
+  '@modelcontextprotocol/sdk@1.13.0':
+    resolution: {integrity: sha512-P5FZsXU0kY881F6Hbk9GhsYx02/KgWK1DYf7/tyE/1lcFKhDYPQR9iYjhQXJn+Sg6hQleMo3DB7h7+p4wgp2Lw==}
     engines: {node: '>=18'}
 
   '@mswjs/interceptors@0.38.7':
@@ -3045,7 +3048,7 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.0
 
-  '@modelcontextprotocol/sdk@1.12.3':
+  '@modelcontextprotocol/sdk@1.13.0':
     dependencies:
       ajv: 6.12.6
       content-type: 1.0.5

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -16,6 +16,7 @@ export {
   handleUnconfirmIssue,
   handleResolveIssue,
   handleReopenIssue,
+  setElicitationManager,
 } from './issues.js';
 
 export { handleSonarQubeGetMetrics } from './metrics.js';

--- a/src/utils/__tests__/elicitation.test.ts
+++ b/src/utils/__tests__/elicitation.test.ts
@@ -1,0 +1,266 @@
+import { describe, it, expect, jest, beforeEach } from '@jest/globals';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { ElicitationManager, createElicitationManager } from '../elicitation.js';
+
+describe('ElicitationManager', () => {
+  let manager: ElicitationManager;
+  let mockServer: jest.Mocked<Server>;
+
+  beforeEach(() => {
+    // Reset environment variables
+    delete process.env.SONARQUBE_MCP_ELICITATION;
+    delete process.env.SONARQUBE_MCP_BULK_THRESHOLD;
+    delete process.env.SONARQUBE_MCP_REQUIRE_COMMENTS;
+    delete process.env.SONARQUBE_MCP_INTERACTIVE_SEARCH;
+
+    manager = new ElicitationManager();
+    mockServer = {
+      elicitInput: jest.fn(),
+    } as unknown as jest.Mocked<Server>;
+  });
+
+  describe('initialization', () => {
+    it('should default to disabled', () => {
+      expect(manager.isEnabled()).toBe(false);
+    });
+
+    it('should not be enabled without a server', () => {
+      manager.updateOptions({ enabled: true });
+      expect(manager.isEnabled()).toBe(false);
+    });
+
+    it('should be enabled with server and enabled option', () => {
+      manager.updateOptions({ enabled: true });
+      manager.setServer(mockServer);
+      expect(manager.isEnabled()).toBe(true);
+    });
+
+    it('should respect environment variables', () => {
+      process.env.SONARQUBE_MCP_ELICITATION = 'true';
+      process.env.SONARQUBE_MCP_BULK_THRESHOLD = '10';
+      process.env.SONARQUBE_MCP_REQUIRE_COMMENTS = 'true';
+      process.env.SONARQUBE_MCP_INTERACTIVE_SEARCH = 'true';
+
+      const envManager = createElicitationManager();
+      expect(envManager.getOptions()).toEqual({
+        enabled: true,
+        bulkOperationThreshold: 10,
+        requireComments: true,
+        interactiveSearch: true,
+      });
+    });
+  });
+
+  describe('confirmBulkOperation', () => {
+    beforeEach(() => {
+      manager.updateOptions({ enabled: true, bulkOperationThreshold: 5 });
+      manager.setServer(mockServer);
+    });
+
+    it('should auto-accept when disabled', async () => {
+      manager.updateOptions({ enabled: false });
+      const result = await manager.confirmBulkOperation('delete', 10);
+      expect(result).toEqual({ action: 'accept', content: { confirm: true } });
+      expect(mockServer.elicitInput).not.toHaveBeenCalled();
+    });
+
+    it('should auto-accept when below threshold', async () => {
+      const result = await manager.confirmBulkOperation('delete', 3);
+      expect(result).toEqual({ action: 'accept', content: { confirm: true } });
+      expect(mockServer.elicitInput).not.toHaveBeenCalled();
+    });
+
+    it('should request confirmation when above threshold', async () => {
+      mockServer.elicitInput.mockResolvedValue({
+        action: 'accept',
+        content: { confirm: true, comment: 'Test comment' },
+      });
+
+      const result = await manager.confirmBulkOperation('delete', 10, ['item1', 'item2']);
+
+      expect(mockServer.elicitInput).toHaveBeenCalledWith({
+        message: expect.stringContaining('delete 10 items'),
+        requestedSchema: expect.objectContaining({
+          properties: expect.objectContaining({
+            confirm: expect.any(Object),
+            comment: expect.any(Object),
+          }),
+        }),
+      });
+
+      expect(result).toEqual({
+        action: 'accept',
+        content: { confirm: true, comment: 'Test comment' },
+      });
+    });
+
+    it('should handle user rejection', async () => {
+      mockServer.elicitInput.mockResolvedValue({
+        action: 'accept',
+        content: { confirm: false },
+      });
+
+      const result = await manager.confirmBulkOperation('delete', 10);
+      expect(result).toEqual({ action: 'reject' });
+    });
+
+    it('should handle cancellation', async () => {
+      mockServer.elicitInput.mockResolvedValue({ action: 'cancel' });
+
+      const result = await manager.confirmBulkOperation('delete', 10);
+      expect(result).toEqual({ action: 'cancel' });
+    });
+
+    it('should handle errors gracefully', async () => {
+      mockServer.elicitInput.mockRejectedValue(new Error('Test error'));
+
+      const result = await manager.confirmBulkOperation('delete', 10);
+      expect(result).toEqual({ action: 'cancel' });
+    });
+  });
+
+  describe('collectAuthentication', () => {
+    beforeEach(() => {
+      manager.updateOptions({ enabled: true });
+      manager.setServer(mockServer);
+    });
+
+    it('should cancel when disabled', async () => {
+      manager.updateOptions({ enabled: false });
+      const result = await manager.collectAuthentication();
+      expect(result).toEqual({ action: 'cancel' });
+    });
+
+    it('should collect token authentication', async () => {
+      mockServer.elicitInput.mockResolvedValue({
+        action: 'accept',
+        content: { method: 'token', token: 'test-token' },
+      });
+
+      const result = await manager.collectAuthentication();
+
+      expect(mockServer.elicitInput).toHaveBeenCalledWith({
+        message: expect.stringContaining('authentication is not configured'),
+        requestedSchema: expect.any(Object),
+      });
+
+      expect(result).toEqual({
+        action: 'accept',
+        content: { method: 'token', token: 'test-token' },
+      });
+    });
+
+    it('should validate authentication schema', async () => {
+      mockServer.elicitInput.mockResolvedValue({
+        action: 'accept',
+        content: { method: 'basic', username: 'user', password: 'pass' },
+      });
+
+      const result = await manager.collectAuthentication();
+      expect(result.action).toBe('accept');
+      expect(result.content).toEqual({
+        method: 'basic',
+        username: 'user',
+        password: 'pass',
+      });
+    });
+  });
+
+  describe('collectResolutionComment', () => {
+    beforeEach(() => {
+      manager.updateOptions({ enabled: true, requireComments: true });
+      manager.setServer(mockServer);
+    });
+
+    it('should auto-accept when comments not required', async () => {
+      manager.updateOptions({ requireComments: false });
+      const result = await manager.collectResolutionComment('ISSUE-123', 'false positive');
+      expect(result).toEqual({ action: 'accept', content: { comment: '' } });
+      expect(mockServer.elicitInput).not.toHaveBeenCalled();
+    });
+
+    it('should request comment when required', async () => {
+      mockServer.elicitInput.mockResolvedValue({
+        action: 'accept',
+        content: { comment: 'This is a test pattern' },
+      });
+
+      const result = await manager.collectResolutionComment('ISSUE-123', 'false positive');
+
+      expect(mockServer.elicitInput).toHaveBeenCalledWith({
+        message: expect.stringContaining('ISSUE-123'),
+        requestedSchema: expect.objectContaining({
+          properties: expect.objectContaining({
+            comment: expect.objectContaining({
+              minLength: 1,
+              maxLength: 500,
+              type: 'string',
+            }),
+          }),
+        }),
+      });
+
+      expect(result).toEqual({
+        action: 'accept',
+        content: { comment: 'This is a test pattern' },
+      });
+    });
+  });
+
+  describe('disambiguateSelection', () => {
+    beforeEach(() => {
+      manager.updateOptions({ enabled: true, interactiveSearch: true });
+      manager.setServer(mockServer);
+    });
+
+    it('should auto-select single item', async () => {
+      const items = [{ name: 'Project A', key: 'proj-a' }];
+      const result = await manager.disambiguateSelection(items, 'project');
+      expect(result).toEqual({ action: 'accept', content: { selection: 'proj-a' } });
+    });
+
+    it('should request selection for multiple items', async () => {
+      const items = [
+        { name: 'Project A', key: 'proj-a' },
+        { name: 'Project B', key: 'proj-b' },
+        { name: 'Project C', key: 'proj-c' },
+      ];
+
+      mockServer.elicitInput.mockResolvedValue({
+        action: 'accept',
+        content: { selection: 'proj-b' },
+      });
+
+      const result = await manager.disambiguateSelection(items, 'project');
+
+      expect(mockServer.elicitInput).toHaveBeenCalledWith({
+        message: expect.stringContaining('Multiple projects found'),
+        requestedSchema: expect.objectContaining({
+          properties: expect.objectContaining({
+            selection: expect.objectContaining({
+              enum: ['proj-a', 'proj-b', 'proj-c'],
+            }),
+          }),
+        }),
+      });
+
+      expect(result).toEqual({
+        action: 'accept',
+        content: { selection: 'proj-b' },
+      });
+    });
+
+    it('should not request when interactive search disabled', async () => {
+      manager.updateOptions({ interactiveSearch: false });
+
+      const items = [
+        { name: 'Project A', key: 'proj-a' },
+        { name: 'Project B', key: 'proj-b' },
+      ];
+
+      const result = await manager.disambiguateSelection(items, 'project');
+      expect(result).toEqual({ action: 'accept', content: { selection: 'proj-a' } });
+      expect(mockServer.elicitInput).not.toHaveBeenCalled();
+    });
+  });
+});

--- a/src/utils/elicitation.ts
+++ b/src/utils/elicitation.ts
@@ -1,0 +1,245 @@
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import { z } from 'zod';
+import { zodToJsonSchema } from 'zod-to-json-schema';
+
+export interface ElicitationOptions {
+  enabled: boolean;
+  bulkOperationThreshold: number;
+  requireComments: boolean;
+  interactiveSearch: boolean;
+}
+
+export interface ElicitationResult<T = unknown> {
+  action: 'accept' | 'reject' | 'cancel';
+  content?: T;
+}
+
+export const confirmationSchema = z.object({
+  confirm: z.boolean().describe('Confirm the operation'),
+  comment: z.string().max(500).optional().describe('Optional comment'),
+});
+
+export const authSchema = z
+  .object({
+    method: z.enum(['token', 'basic', 'passcode']).describe('Authentication method'),
+    token: z.string().optional().describe('SonarQube token (for token auth)'),
+    username: z.string().optional().describe('Username (for basic auth)'),
+    password: z.string().optional().describe('Password (for basic auth)'),
+    passcode: z.string().optional().describe('System passcode'),
+  })
+  .refine(
+    (data) => {
+      if (data.method === 'token' && !data.token) return false;
+      if (data.method === 'basic' && (!data.username || !data.password)) return false;
+      if (data.method === 'passcode' && !data.passcode) return false;
+      return true;
+    },
+    {
+      message: 'Required fields missing for selected authentication method',
+    }
+  );
+
+export class ElicitationManager {
+  private server: Server | null = null;
+  private options: ElicitationOptions;
+
+  constructor(options: Partial<ElicitationOptions> = {}) {
+    this.options = {
+      enabled: false,
+      bulkOperationThreshold: 5,
+      requireComments: false,
+      interactiveSearch: false,
+      ...options,
+    };
+  }
+
+  setServer(server: Server): void {
+    this.server = server;
+  }
+
+  isEnabled(): boolean {
+    return this.options.enabled && this.server !== null;
+  }
+
+  getOptions(): ElicitationOptions {
+    return { ...this.options };
+  }
+
+  updateOptions(updates: Partial<ElicitationOptions>): void {
+    this.options = { ...this.options, ...updates };
+  }
+
+  async confirmBulkOperation(
+    operation: string,
+    itemCount: number,
+    items?: string[]
+  ): Promise<ElicitationResult<z.infer<typeof confirmationSchema>>> {
+    if (!this.isEnabled() || itemCount < this.options.bulkOperationThreshold) {
+      return { action: 'accept', content: { confirm: true } };
+    }
+
+    if (!this.server) {
+      throw new Error('ElicitationManager not initialized with server');
+    }
+
+    const itemsPreview = items?.slice(0, 5).join(', ');
+    const hasMore = items && items.length > 5;
+
+    try {
+      const result = await this.server.elicitInput({
+        message: `You are about to ${operation} ${itemCount} items${
+          itemsPreview ? `: ${itemsPreview}${hasMore ? ', ...' : ''}` : ''
+        }. This action cannot be undone.`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        requestedSchema: zodToJsonSchema(confirmationSchema) as any,
+      });
+
+      if (result.action === 'accept' && result.content) {
+        const parsed = confirmationSchema.parse(result.content);
+        if (!parsed.confirm) {
+          return { action: 'reject' };
+        }
+        return { action: 'accept', content: parsed };
+      }
+
+      return result as ElicitationResult<z.infer<typeof confirmationSchema>>;
+    } catch (error) {
+      console.error('Elicitation error:', error);
+      return { action: 'cancel' };
+    }
+  }
+
+  async collectAuthentication(): Promise<ElicitationResult<z.infer<typeof authSchema>>> {
+    if (!this.isEnabled()) {
+      return { action: 'cancel' };
+    }
+
+    if (!this.server) {
+      throw new Error('ElicitationManager not initialized with server');
+    }
+
+    try {
+      const result = await this.server.elicitInput({
+        message: `SonarQube authentication is not configured. Please provide authentication details:
+
+Available methods:
+1. Token authentication (recommended) - Generate a token in SonarQube under User > My Account > Security
+2. Basic authentication - Username and password
+3. System passcode - For SonarQube instances with system authentication
+
+Which method would you like to use?`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        requestedSchema: zodToJsonSchema(authSchema) as any,
+      });
+
+      if (result.action === 'accept' && result.content) {
+        const parsed = authSchema.parse(result.content);
+        return { action: 'accept', content: parsed };
+      }
+
+      return result as ElicitationResult<z.infer<typeof authSchema>>;
+    } catch (error) {
+      console.error('Elicitation error:', error);
+      return { action: 'cancel' };
+    }
+  }
+
+  async collectResolutionComment(
+    issueKey: string,
+    resolution: string
+  ): Promise<ElicitationResult<{ comment: string }>> {
+    if (!this.isEnabled() || !this.options.requireComments) {
+      return { action: 'accept', content: { comment: '' } };
+    }
+
+    if (!this.server) {
+      throw new Error('ElicitationManager not initialized with server');
+    }
+
+    const commentSchema = z.object({
+      comment: z.string().min(1).max(500).describe(`Explanation for marking as ${resolution}`),
+    });
+
+    try {
+      const result = await this.server.elicitInput({
+        message: `Please provide a comment explaining why issue ${issueKey} is being marked as ${resolution}:`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        requestedSchema: zodToJsonSchema(commentSchema) as any,
+      });
+
+      if (result.action === 'accept' && result.content) {
+        const parsed = commentSchema.parse(result.content);
+        return { action: 'accept', content: parsed };
+      }
+
+      return result as ElicitationResult<{ comment: string }>;
+    } catch (error) {
+      console.error('Elicitation error:', error);
+      return { action: 'cancel' };
+    }
+  }
+
+  async disambiguateSelection<T extends { name: string; key: string }>(
+    items: T[],
+    itemType: string
+  ): Promise<ElicitationResult<{ selection: string }>> {
+    if (!this.isEnabled() || !this.options.interactiveSearch || items.length <= 1) {
+      return {
+        action: 'accept',
+        content: { selection: items[0]?.key || '' },
+      };
+    }
+
+    if (!this.server) {
+      throw new Error('ElicitationManager not initialized with server');
+    }
+
+    const selectionSchema = z.object({
+      selection: z
+        .enum(items.map((item) => item.key) as [string, ...string[]])
+        .describe(`Select a ${itemType}`),
+    });
+
+    const itemsList = items
+      .slice(0, 10)
+      .map((item, i) => `${i + 1}. ${item.name} (${item.key})`)
+      .join('\n');
+
+    try {
+      const result = await this.server.elicitInput({
+        message: `Multiple ${itemType}s found. Please select one:\n\n${itemsList}`,
+        // eslint-disable-next-line @typescript-eslint/no-explicit-any
+        requestedSchema: zodToJsonSchema(selectionSchema) as any,
+      });
+
+      if (result.action === 'accept' && result.content) {
+        const parsed = selectionSchema.parse(result.content);
+        return { action: 'accept', content: parsed };
+      }
+
+      return result as ElicitationResult<{ selection: string }>;
+    } catch (error) {
+      console.error('Elicitation error:', error);
+      return { action: 'cancel' };
+    }
+  }
+}
+
+export const createElicitationManager = (
+  options?: Partial<ElicitationOptions>
+): ElicitationManager => {
+  const envEnabled = process.env.SONARQUBE_MCP_ELICITATION === 'true';
+  const envThreshold = process.env.SONARQUBE_MCP_BULK_THRESHOLD
+    ? parseInt(process.env.SONARQUBE_MCP_BULK_THRESHOLD, 10)
+    : undefined;
+  const envRequireComments = process.env.SONARQUBE_MCP_REQUIRE_COMMENTS === 'true';
+  const envInteractiveSearch = process.env.SONARQUBE_MCP_INTERACTIVE_SEARCH === 'true';
+
+  return new ElicitationManager({
+    enabled: envEnabled,
+    bulkOperationThreshold: envThreshold || options?.bulkOperationThreshold,
+    requireComments: envRequireComments || options?.requireComments,
+    interactiveSearch: envInteractiveSearch || options?.interactiveSearch,
+    ...options,
+  });
+};


### PR DESCRIPTION
## Summary
This PR adds support for MCP's elicitation capability, enabling interactive user input collection for improved safety and user experience.

## Changes
- 🔄 Upgrade MCP SDK from v1.12.3 to v1.13.0 to enable elicitation capability
- 🛡️ Add bulk operation confirmations (>5 items trigger confirmation prompts)
- 💬 Add context collection for issue resolutions (collects explanatory comments)
- 🔐 Add authentication setup assistance when credentials are missing
- ⚙️ Make feature opt-in via `SONARQUBE_MCP_ELICITATION=true` environment variable
- 📊 Add comprehensive configuration options for thresholds and behavior
- ✅ Include full test coverage for elicitation flows
- 📚 Update documentation with v1.6.0 release notes and configuration guide

## Key Features

### 1. Bulk Operation Safety
Before marking multiple issues as false positive or won't fix, the server will request confirmation:
```
You are about to mark as false positive 10 items: ISSUE-1, ISSUE-2, ISSUE-3, ISSUE-4, ISSUE-5, ...
This action cannot be undone.
```

### 2. Context Collection
When marking issues, the server can collect explanatory comments:
```
Please provide a comment explaining why issue ISSUE-123 is being marked as false positive:
```

### 3. Authentication Assistance
If no authentication is configured, the server guides users through setup:
```
SonarQube authentication is not configured. Please provide authentication details:

Available methods:
1. Token authentication (recommended)
2. Basic authentication
3. System passcode
```

## Configuration
Enable elicitation and customize behavior with environment variables:
- `SONARQUBE_MCP_ELICITATION=true` - Enable elicitation
- `SONARQUBE_MCP_BULK_THRESHOLD=10` - Items before confirmation (default: 5)
- `SONARQUBE_MCP_REQUIRE_COMMENTS=true` - Require comments for resolutions
- `SONARQUBE_MCP_INTERACTIVE_SEARCH=true` - Enable search disambiguation

## Testing
- Added comprehensive unit tests for all elicitation scenarios
- Tests cover confirmation, authentication, comment collection, and disambiguation
- All existing tests pass, ensuring backward compatibility

## Breaking Changes
None - the feature is fully backward compatible and opt-in. When disabled, the server behaves exactly as before.

## Architecture Decision
See ADR-0012: [Add Elicitation Support for Interactive User Input](doc/architecture/decisions/0012-add-elicitation-support-for-interactive-user-input.md)

🤖 Generated with [Claude Code](https://claude.ai/code)