### PR TITLE
fix: Accept pull_request parameter as number or string

### DIFF
--- a/src/__tests__/pull-request-transform.test.ts
+++ b/src/__tests__/pull-request-transform.test.ts
@@ -1,0 +1,157 @@
+import { describe, test, expect } from '@jest/globals';
+import { z } from 'zod';
+import { issuesToolSchema } from '../schemas/issues';
+import {
+  componentMeasuresToolSchema,
+  componentsMeasuresToolSchema,
+  measuresHistoryToolSchema,
+} from '../schemas/measures';
+import { hotspotsToolSchema } from '../schemas/hotspots-tools';
+import { sourceCodeToolSchema, scmBlameToolSchema } from '../schemas/source-code';
+import { qualityGateStatusToolSchema } from '../schemas/quality-gates';
+import { componentsToolSchema } from '../schemas/components';
+
+describe('pull_request parameter transform', () => {
+  describe('issues schema', () => {
+    test('accepts string pull_request', () => {
+      const schema = z.object(issuesToolSchema);
+      const result = schema.parse({
+        pull_request: '123',
+      });
+      expect(result.pull_request).toBe('123');
+    });
+
+    test('accepts number pull_request and converts to string', () => {
+      const schema = z.object(issuesToolSchema);
+      const result = schema.parse({
+        pull_request: 123,
+      });
+      expect(result.pull_request).toBe('123');
+    });
+
+    test('preserves null values', () => {
+      const schema = z.object(issuesToolSchema);
+      const result = schema.parse({
+        pull_request: null,
+      });
+      expect(result.pull_request).toBeNull();
+    });
+  });
+
+  describe('measures schemas', () => {
+    test('componentMeasuresToolSchema accepts number and converts to string', () => {
+      const schema = z.object(componentMeasuresToolSchema);
+      const result = schema.parse({
+        component: 'test',
+        metric_keys: ['coverage'],
+        pull_request: 456,
+      });
+      expect(result.pull_request).toBe('456');
+    });
+
+    test('componentsMeasuresToolSchema accepts number and converts to string', () => {
+      const schema = z.object(componentsMeasuresToolSchema);
+      const result = schema.parse({
+        component_keys: ['test'],
+        metric_keys: ['coverage'],
+        pull_request: 789,
+      });
+      expect(result.pull_request).toBe('789');
+    });
+
+    test('measuresHistoryToolSchema accepts number and converts to string', () => {
+      const schema = z.object(measuresHistoryToolSchema);
+      const result = schema.parse({
+        component: 'test',
+        metrics: ['coverage'],
+        pull_request: 999,
+      });
+      expect(result.pull_request).toBe('999');
+    });
+  });
+
+  describe('hotspots schema', () => {
+    test('accepts number pull_request and converts to string', () => {
+      const schema = z.object(hotspotsToolSchema);
+      const result = schema.parse({
+        pull_request: 111,
+      });
+      expect(result.pull_request).toBe('111');
+    });
+  });
+
+  describe('source code schemas', () => {
+    test('sourceCodeToolSchema accepts number and converts to string', () => {
+      const schema = z.object(sourceCodeToolSchema);
+      const result = schema.parse({
+        key: 'test',
+        pull_request: 222,
+      });
+      expect(result.pull_request).toBe('222');
+    });
+
+    test('scmBlameToolSchema accepts number and converts to string', () => {
+      const schema = z.object(scmBlameToolSchema);
+      const result = schema.parse({
+        key: 'test',
+        pull_request: 333,
+      });
+      expect(result.pull_request).toBe('333');
+    });
+  });
+
+  describe('quality gates schema', () => {
+    test('accepts number pull_request and converts to string', () => {
+      const schema = z.object(qualityGateStatusToolSchema);
+      const result = schema.parse({
+        project_key: 'test',
+        pull_request: 444,
+      });
+      expect(result.pull_request).toBe('444');
+    });
+  });
+
+  describe('components schema', () => {
+    test('accepts number pullRequest and converts to string', () => {
+      const schema = z.object(componentsToolSchema);
+      const result = schema.parse({
+        pullRequest: 555,
+      });
+      expect(result.pullRequest).toBe('555');
+    });
+
+    test('accepts string pullRequest', () => {
+      const schema = z.object(componentsToolSchema);
+      const result = schema.parse({
+        pullRequest: 'pr-666',
+      });
+      expect(result.pullRequest).toBe('pr-666');
+    });
+  });
+
+  describe('edge cases', () => {
+    test('handles decimal numbers', () => {
+      const schema = z.object(issuesToolSchema);
+      const result = schema.parse({
+        pull_request: 123.456,
+      });
+      expect(result.pull_request).toBe('123.456');
+    });
+
+    test('handles negative numbers', () => {
+      const schema = z.object(issuesToolSchema);
+      const result = schema.parse({
+        pull_request: -123,
+      });
+      expect(result.pull_request).toBe('-123');
+    });
+
+    test('handles zero', () => {
+      const schema = z.object(issuesToolSchema);
+      const result = schema.parse({
+        pull_request: 0,
+      });
+      expect(result.pull_request).toBe('0');
+    });
+  });
+});

--- a/src/__tests__/utils/transforms.test.ts
+++ b/src/__tests__/utils/transforms.test.ts
@@ -4,6 +4,7 @@ import {
   ensureStringArray,
   nullToUndefined,
   stringToNumberTransform,
+  numberOrStringToString,
 } from '../../utils/transforms';
 
 describe('transforms', () => {
@@ -105,6 +106,35 @@ describe('transforms', () => {
     test('handles strings with no commas', () => {
       expect(ensureStringArray('nocommas')).toEqual(['nocommas']);
       expect(ensureStringArray('single-value')).toEqual(['single-value']);
+    });
+  });
+
+  describe('numberOrStringToString', () => {
+    test('converts number to string', () => {
+      expect(numberOrStringToString(123)).toBe('123');
+      expect(numberOrStringToString(0)).toBe('0');
+      expect(numberOrStringToString(-456)).toBe('-456');
+      expect(numberOrStringToString(12.34)).toBe('12.34');
+    });
+
+    test('preserves string values', () => {
+      expect(numberOrStringToString('123')).toBe('123');
+      expect(numberOrStringToString('abc')).toBe('abc');
+      expect(numberOrStringToString('')).toBe('');
+      expect(numberOrStringToString('pr-123')).toBe('pr-123');
+    });
+
+    test('preserves null and undefined', () => {
+      expect(numberOrStringToString(null)).toBeNull();
+      expect(numberOrStringToString(undefined)).toBeUndefined();
+    });
+
+    test('handles edge cases', () => {
+      expect(numberOrStringToString(0)).toBe('0');
+      expect(numberOrStringToString('')).toBe('');
+      expect(numberOrStringToString(NaN)).toBe('NaN');
+      expect(numberOrStringToString(Infinity)).toBe('Infinity');
+      expect(numberOrStringToString(-Infinity)).toBe('-Infinity');
     });
   });
 });

--- a/src/schemas/common.ts
+++ b/src/schemas/common.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { numberOrStringToString } from '../utils/transforms.js';
 
 /**
  * Common schemas used across multiple domains
@@ -48,3 +49,16 @@ export const impactSoftwareQualitiesSchema = z
   .array(z.enum(['MAINTAINABILITY', 'RELIABILITY', 'SECURITY']))
   .nullable()
   .optional();
+
+// Pull request schema - accepts either string or number and converts to string
+export const pullRequestSchema = z
+  .union([z.string(), z.number()])
+  .optional()
+  .transform(numberOrStringToString);
+
+// Pull request schema with nullable - for schemas that allow null values
+export const pullRequestNullableSchema = z
+  .union([z.string(), z.number()])
+  .nullable()
+  .optional()
+  .transform(numberOrStringToString);

--- a/src/schemas/components.ts
+++ b/src/schemas/components.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { stringToNumberTransform, numberOrStringToString } from '../utils/transforms.js';
+import { stringToNumberTransform } from '../utils/transforms.js';
+import { pullRequestSchema } from './common.js';
 
 /**
  * Valid component qualifiers based on SonarQube API
@@ -49,9 +50,5 @@ export const componentsToolSchema = {
 
   // Additional filters
   branch: z.string().optional().describe('Branch name'),
-  pullRequest: z
-    .union([z.string(), z.number()])
-    .optional()
-    .transform(numberOrStringToString)
-    .describe('Pull request ID'),
+  pullRequest: pullRequestSchema.describe('Pull request ID'),
 };

--- a/src/schemas/components.ts
+++ b/src/schemas/components.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { stringToNumberTransform } from '../utils/transforms.js';
+import { stringToNumberTransform, numberOrStringToString } from '../utils/transforms.js';
 
 /**
  * Valid component qualifiers based on SonarQube API
@@ -49,5 +49,9 @@ export const componentsToolSchema = {
 
   // Additional filters
   branch: z.string().optional().describe('Branch name'),
-  pullRequest: z.string().optional().describe('Pull request ID'),
+  pullRequest: z
+    .union([z.string(), z.number()])
+    .optional()
+    .transform(numberOrStringToString)
+    .describe('Pull request ID'),
 };

--- a/src/schemas/hotspots-tools.ts
+++ b/src/schemas/hotspots-tools.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { stringToNumberTransform } from '../utils/transforms.js';
+import { stringToNumberTransform, numberOrStringToString } from '../utils/transforms.js';
 import { hotspotStatusSchema, hotspotResolutionSchema } from './hotspots.js';
 
 /**
@@ -9,7 +9,11 @@ import { hotspotStatusSchema, hotspotResolutionSchema } from './hotspots.js';
 export const hotspotsToolSchema = {
   project_key: z.string().optional(),
   branch: z.string().nullable().optional(),
-  pull_request: z.string().nullable().optional(),
+  pull_request: z
+    .union([z.string(), z.number()])
+    .nullable()
+    .optional()
+    .transform(numberOrStringToString),
   status: hotspotStatusSchema,
   resolution: hotspotResolutionSchema,
   files: z.array(z.string()).nullable().optional(),

--- a/src/schemas/hotspots-tools.ts
+++ b/src/schemas/hotspots-tools.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { stringToNumberTransform, numberOrStringToString } from '../utils/transforms.js';
+import { stringToNumberTransform } from '../utils/transforms.js';
+import { pullRequestNullableSchema } from './common.js';
 import { hotspotStatusSchema, hotspotResolutionSchema } from './hotspots.js';
 
 /**
@@ -9,11 +10,7 @@ import { hotspotStatusSchema, hotspotResolutionSchema } from './hotspots.js';
 export const hotspotsToolSchema = {
   project_key: z.string().optional(),
   branch: z.string().nullable().optional(),
-  pull_request: z
-    .union([z.string(), z.number()])
-    .nullable()
-    .optional()
-    .transform(numberOrStringToString),
+  pull_request: pullRequestNullableSchema,
   status: hotspotStatusSchema,
   resolution: hotspotResolutionSchema,
   files: z.array(z.string()).nullable().optional(),

--- a/src/schemas/issues.ts
+++ b/src/schemas/issues.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { stringToNumberTransform, numberOrStringToString } from '../utils/transforms.js';
+import { stringToNumberTransform } from '../utils/transforms.js';
 import {
   severitySchema,
   severitiesSchema,
@@ -9,6 +9,7 @@ import {
   cleanCodeAttributeCategoriesSchema,
   impactSeveritiesSchema,
   impactSoftwareQualitiesSchema,
+  pullRequestNullableSchema,
 } from './common.js';
 
 /**
@@ -155,11 +156,7 @@ export const issuesToolSchema = {
 
   // Branch and PR support
   branch: z.string().nullable().optional(),
-  pull_request: z
-    .union([z.string(), z.number()])
-    .nullable()
-    .optional()
-    .transform(numberOrStringToString),
+  pull_request: pullRequestNullableSchema,
 
   // Issue filters
   issues: z.array(z.string()).nullable().optional(),

--- a/src/schemas/issues.ts
+++ b/src/schemas/issues.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { stringToNumberTransform } from '../utils/transforms.js';
+import { stringToNumberTransform, numberOrStringToString } from '../utils/transforms.js';
 import {
   severitySchema,
   severitiesSchema,
@@ -155,7 +155,11 @@ export const issuesToolSchema = {
 
   // Branch and PR support
   branch: z.string().nullable().optional(),
-  pull_request: z.string().nullable().optional(),
+  pull_request: z
+    .union([z.string(), z.number()])
+    .nullable()
+    .optional()
+    .transform(numberOrStringToString),
 
   // Issue filters
   issues: z.array(z.string()).nullable().optional(),

--- a/src/schemas/measures.ts
+++ b/src/schemas/measures.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { stringToNumberTransform } from '../utils/transforms.js';
+import { stringToNumberTransform, numberOrStringToString } from '../utils/transforms.js';
 
 /**
  * Schemas for measures tools
@@ -10,7 +10,7 @@ export const componentMeasuresToolSchema = {
   metric_keys: z.array(z.string()),
   additional_fields: z.array(z.string()).optional(),
   branch: z.string().optional(),
-  pull_request: z.string().optional(),
+  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
   period: z.string().optional(),
 };
 
@@ -19,7 +19,7 @@ export const componentsMeasuresToolSchema = {
   metric_keys: z.array(z.string()),
   additional_fields: z.array(z.string()).optional(),
   branch: z.string().optional(),
-  pull_request: z.string().optional(),
+  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
   period: z.string().optional(),
   page: z.string().optional().transform(stringToNumberTransform),
   page_size: z.string().optional().transform(stringToNumberTransform),
@@ -31,7 +31,7 @@ export const measuresHistoryToolSchema = {
   from: z.string().optional(),
   to: z.string().optional(),
   branch: z.string().optional(),
-  pull_request: z.string().optional(),
+  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
   page: z.string().optional().transform(stringToNumberTransform),
   page_size: z.string().optional().transform(stringToNumberTransform),
 };

--- a/src/schemas/measures.ts
+++ b/src/schemas/measures.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { stringToNumberTransform, numberOrStringToString } from '../utils/transforms.js';
+import { stringToNumberTransform } from '../utils/transforms.js';
+import { pullRequestSchema } from './common.js';
 
 /**
  * Schemas for measures tools
@@ -10,7 +11,7 @@ export const componentMeasuresToolSchema = {
   metric_keys: z.array(z.string()),
   additional_fields: z.array(z.string()).optional(),
   branch: z.string().optional(),
-  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
+  pull_request: pullRequestSchema,
   period: z.string().optional(),
 };
 
@@ -19,7 +20,7 @@ export const componentsMeasuresToolSchema = {
   metric_keys: z.array(z.string()),
   additional_fields: z.array(z.string()).optional(),
   branch: z.string().optional(),
-  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
+  pull_request: pullRequestSchema,
   period: z.string().optional(),
   page: z.string().optional().transform(stringToNumberTransform),
   page_size: z.string().optional().transform(stringToNumberTransform),
@@ -31,7 +32,7 @@ export const measuresHistoryToolSchema = {
   from: z.string().optional(),
   to: z.string().optional(),
   branch: z.string().optional(),
-  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
+  pull_request: pullRequestSchema,
   page: z.string().optional().transform(stringToNumberTransform),
   page_size: z.string().optional().transform(stringToNumberTransform),
 };

--- a/src/schemas/quality-gates.ts
+++ b/src/schemas/quality-gates.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { numberOrStringToString } from '../utils/transforms.js';
+import { pullRequestSchema } from './common.js';
 
 /**
  * Schemas for quality gates tools
@@ -14,5 +14,5 @@ export const qualityGateToolSchema = {
 export const qualityGateStatusToolSchema = {
   project_key: z.string(),
   branch: z.string().optional(),
-  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
+  pull_request: pullRequestSchema,
 };

--- a/src/schemas/quality-gates.ts
+++ b/src/schemas/quality-gates.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { numberOrStringToString } from '../utils/transforms.js';
 
 /**
  * Schemas for quality gates tools
@@ -13,5 +14,5 @@ export const qualityGateToolSchema = {
 export const qualityGateStatusToolSchema = {
   project_key: z.string(),
   branch: z.string().optional(),
-  pull_request: z.string().optional(),
+  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
 };

--- a/src/schemas/source-code.ts
+++ b/src/schemas/source-code.ts
@@ -1,5 +1,5 @@
 import { z } from 'zod';
-import { stringToNumberTransform } from '../utils/transforms.js';
+import { stringToNumberTransform, numberOrStringToString } from '../utils/transforms.js';
 
 /**
  * Schemas for source code tools
@@ -10,7 +10,7 @@ export const sourceCodeToolSchema = {
   from: z.string().optional().transform(stringToNumberTransform),
   to: z.string().optional().transform(stringToNumberTransform),
   branch: z.string().optional(),
-  pull_request: z.string().optional(),
+  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
 };
 
 export const scmBlameToolSchema = {
@@ -18,5 +18,5 @@ export const scmBlameToolSchema = {
   from: z.string().optional().transform(stringToNumberTransform),
   to: z.string().optional().transform(stringToNumberTransform),
   branch: z.string().optional(),
-  pull_request: z.string().optional(),
+  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
 };

--- a/src/schemas/source-code.ts
+++ b/src/schemas/source-code.ts
@@ -1,5 +1,6 @@
 import { z } from 'zod';
-import { stringToNumberTransform, numberOrStringToString } from '../utils/transforms.js';
+import { stringToNumberTransform } from '../utils/transforms.js';
+import { pullRequestSchema } from './common.js';
 
 /**
  * Schemas for source code tools
@@ -10,7 +11,7 @@ export const sourceCodeToolSchema = {
   from: z.string().optional().transform(stringToNumberTransform),
   to: z.string().optional().transform(stringToNumberTransform),
   branch: z.string().optional(),
-  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
+  pull_request: pullRequestSchema,
 };
 
 export const scmBlameToolSchema = {
@@ -18,5 +19,5 @@ export const scmBlameToolSchema = {
   from: z.string().optional().transform(stringToNumberTransform),
   to: z.string().optional().transform(stringToNumberTransform),
   branch: z.string().optional(),
-  pull_request: z.union([z.string(), z.number()]).optional().transform(numberOrStringToString),
+  pull_request: pullRequestSchema,
 };

--- a/src/utils/transforms.ts
+++ b/src/utils/transforms.ts
@@ -43,3 +43,18 @@ export function ensureStringArray(value: string | string[] | undefined): string[
   if (value.includes(',')) return value.split(',').map((s) => s.trim());
   return [value];
 }
+
+/**
+ * Converts a number or string to a string
+ * Useful for parameters that can be passed as either type but need to be strings for the API
+ * @param value Number, string, null, or undefined
+ * @returns String representation of the value, or the original null/undefined
+ */
+export function numberOrStringToString(
+  value: number | string | null | undefined
+): string | null | undefined {
+  if (value === null || value === undefined) {
+    return value;
+  }
+  return String(value);
+}


### PR DESCRIPTION
## Summary
This PR fixes an issue where MCP clients passing `pull_request` as a number would receive an error because the schema expects a string. This change makes the API more user-friendly by accepting both formats.

## Changes
- Added `numberOrStringToString` transform function in `utils/transforms.ts`
- Updated all schema definitions that have `pull_request` or `pullRequest` fields to accept both number and string types
- Added comprehensive tests to verify the transform works correctly

## Affected Schemas
- **issues.ts**: `pull_request` field
- **measures.ts**: `pull_request` field in all 3 schemas (componentMeasuresToolSchema, componentsMeasuresToolSchema, measuresHistoryToolSchema)
- **hotspots-tools.ts**: `pull_request` field
- **source-code.ts**: `pull_request` field in both schemas (sourceCodeToolSchema, scmBlameToolSchema)
- **quality-gates.ts**: `pull_request` field
- **components.ts**: `pullRequest` field

## Testing
- Added new test file `src/__tests__/pull-request-transform.test.ts` with 15 test cases
- Tests verify that:
  - String values are preserved (e.g., "123" → "123")
  - Number values are converted to strings (e.g., 123 → "123")
  - Null values are preserved
  - Edge cases work correctly (decimals, negative numbers, zero)
- All existing tests continue to pass

## Example
Before this change:
```javascript
// This would fail with a validation error
await mcp.call('issues', { pull_request: 123 });
```

After this change:
```javascript
// Both of these work correctly
await mcp.call('issues', { pull_request: 123 });    // number → "123"
await mcp.call('issues', { pull_request: "123" }); // string → "123"
```

🤖 Generated with [Claude Code](https://claude.ai/code)