### PR TITLE
feat: Add JSON string array support for MCP parameters

### DIFF
--- a/src/__tests__/json-array-transform.test.ts
+++ b/src/__tests__/json-array-transform.test.ts
@@ -1,6 +1,13 @@
 import { z } from 'zod';
 import { parseJsonStringArray } from '../utils/transforms.js';
 import { issuesToolSchema } from '../schemas/issues.js';
+import {
+  resolutionSchema,
+  typeSchema,
+  cleanCodeAttributeCategoriesSchema,
+  impactSeveritiesSchema,
+  impactSoftwareQualitiesSchema,
+} from '../schemas/common.js';
 
 describe('JSON Array Transform', () => {
   describe('parseJsonStringArray', () => {
@@ -97,6 +104,108 @@ describe('JSON Array Transform', () => {
       expect(result.project_key).toBe('sonarqube-mcp-server');
       expect(result.page_size).toBe(50); // Transformed by stringToNumberTransform
       expect(result.facets).toEqual(['severities', 'statuses', 'types', 'rules', 'files']);
+    });
+
+    test('handles resolutions with JSON strings and filters invalid values', () => {
+      const result = schema.parse({
+        resolutions: '["FALSE-POSITIVE", "INVALID", "WONTFIX"]',
+      });
+
+      expect(result.resolutions).toEqual(['FALSE-POSITIVE', 'WONTFIX']);
+    });
+
+    test('handles types with JSON strings and filters invalid values', () => {
+      const result = schema.parse({
+        types: '["BUG", "INVALID_TYPE", "VULNERABILITY"]',
+      });
+
+      expect(result.types).toEqual(['BUG', 'VULNERABILITY']);
+    });
+
+    test('handles clean code attributes with JSON strings', () => {
+      const result = schema.parse({
+        clean_code_attribute_categories: '["ADAPTABLE", "INVALID", "CONSISTENT"]',
+      });
+
+      expect(result.clean_code_attribute_categories).toEqual(['ADAPTABLE', 'CONSISTENT']);
+    });
+
+    test('handles impact severities with JSON strings', () => {
+      const result = schema.parse({
+        impact_severities: '["HIGH", "INVALID", "LOW"]',
+      });
+
+      expect(result.impact_severities).toEqual(['HIGH', 'LOW']);
+    });
+
+    test('handles impact software qualities with JSON strings', () => {
+      const result = schema.parse({
+        impact_software_qualities: '["MAINTAINABILITY", "INVALID", "SECURITY"]',
+      });
+
+      expect(result.impact_software_qualities).toEqual(['MAINTAINABILITY', 'SECURITY']);
+    });
+  });
+
+  describe('common schemas with JSON arrays', () => {
+    test('resolutionSchema accepts JSON strings and filters invalid values', () => {
+      const schema = z.object({ resolution: resolutionSchema });
+
+      const result = schema.parse({
+        resolution: '["FALSE-POSITIVE", "INVALID_RESOLUTION", "FIXED"]',
+      });
+
+      expect(result.resolution).toEqual(['FALSE-POSITIVE', 'FIXED']);
+    });
+
+    test('resolutionSchema accepts arrays directly', () => {
+      const schema = z.object({ resolution: resolutionSchema });
+
+      const result = schema.parse({
+        resolution: ['WONTFIX', 'REMOVED'],
+      });
+
+      expect(result.resolution).toEqual(['WONTFIX', 'REMOVED']);
+    });
+
+    test('typeSchema accepts JSON strings and filters invalid values', () => {
+      const schema = z.object({ type: typeSchema });
+
+      const result = schema.parse({
+        type: '["CODE_SMELL", "INVALID_TYPE", "BUG"]',
+      });
+
+      expect(result.type).toEqual(['CODE_SMELL', 'BUG']);
+    });
+
+    test('cleanCodeAttributeCategoriesSchema accepts JSON strings', () => {
+      const schema = z.object({ categories: cleanCodeAttributeCategoriesSchema });
+
+      const result = schema.parse({
+        categories: '["INTENTIONAL", "INVALID_CATEGORY", "RESPONSIBLE"]',
+      });
+
+      expect(result.categories).toEqual(['INTENTIONAL', 'RESPONSIBLE']);
+    });
+
+    test('impactSeveritiesSchema accepts JSON strings', () => {
+      const schema = z.object({ severities: impactSeveritiesSchema });
+
+      const result = schema.parse({
+        severities: '["HIGH", "INVALID_SEVERITY", "MEDIUM"]',
+      });
+
+      expect(result.severities).toEqual(['HIGH', 'MEDIUM']);
+    });
+
+    test('impactSoftwareQualitiesSchema accepts JSON strings', () => {
+      const schema = z.object({ qualities: impactSoftwareQualitiesSchema });
+
+      const result = schema.parse({
+        qualities: '["RELIABILITY", "INVALID_QUALITY", "SECURITY"]',
+      });
+
+      expect(result.qualities).toEqual(['RELIABILITY', 'SECURITY']);
     });
   });
 });


### PR DESCRIPTION
## Summary
This PR fixes an issue where MCP clients passing array parameters as JSON strings would receive validation errors. The solution adds automatic parsing and validation of JSON string arrays while maintaining backward compatibility.

## Problem
When MCP clients call the issues tool with parameters like:
```javascript
sonarqube:issues({
  project_key: "sonarqube-mcp-server",
  facets: '["severities", "statuses", "types", "rules", "files"]'
})
```

They receive an error:
```
MCP error -32602: Invalid arguments for tool issues: Expected array, received string
```

## Solution
- Added `parseJsonStringArray` transform function that:
  - Accepts arrays, JSON strings, null, or undefined
  - Parses valid JSON string arrays
  - Treats invalid JSON strings as single-item arrays
- Updated all array fields in `issues` and `common` schemas to accept both formats
- Added validation for enum arrays to filter out invalid values
- Comprehensive test coverage for all scenarios

## Changes
- Added `parseJsonStringArray` transform function in `src/utils/transforms.ts`
- Updated array fields in `src/schemas/issues.ts` to use the transform
- Updated enum array schemas in `src/schemas/common.ts` with validation
- Added comprehensive tests in `src/__tests__/json-array-transform.test.ts`

## Testing
All tests pass, including new tests that verify:
- The transform function handles all input types correctly
- The issues schema accepts both array and JSON string formats
- Invalid enum values are filtered out
- The exact MCP client scenario works as expected

## Backward Compatibility
This change is fully backward compatible. Existing clients passing arrays will continue to work exactly as before.

🤖 Generated with [Claude Code](https://claude.ai/code)