### PR TITLE
fix: resolve MCP array serialization schema issue

### DIFF
--- a/mcp_sonar/src/index.ts
+++ b/mcp_sonar/src/index.ts
@@ -1,0 +1,939 @@
+#!/usr/bin/env node
+
+import { McpServer } from '@modelcontextprotocol/sdk/server/mcp.js';
+import { Server } from '@modelcontextprotocol/sdk/server/index.js';
+import {
+  ISonarQubeClient,
+  createSonarQubeClientFromEnv,
+  setSonarQubeElicitationManager,
+  HotspotSearchParams,
+  HotspotStatusUpdateParams,
+} from './sonarqube.js';
+import type { ComponentQualifier } from './types/components.js';
+import { createLogger } from './utils/logger.js';
+import { nullToUndefined, ensureStringArray, parseJsonStringArray } from './utils/transforms.js';
+import { mapToSonarQubeParams } from './utils/parameter-mappers.js';
+import { validateEnvironmentVariables, resetDefaultClient } from './utils/client-factory.js';
+import { createElicitationManager } from './utils/elicitation.js';
+import { SERVER_VERSION, VERSION_INFO } from './config/versions.js';
+import { TransportFactory } from './transports/index.js';
+import { getPermissionManager } from './auth/permission-manager.js';
+import {
+  handleSonarQubeProjects,
+  handleSonarQubeGetIssues,
+  handleMarkIssueFalsePositive,
+  handleMarkIssueWontFix,
+  handleMarkIssuesFalsePositive,
+  handleMarkIssuesWontFix,
+  handleSonarQubeGetMetrics,
+  handleSonarQubeGetHealth,
+  handleSonarQubeGetStatus,
+  handleSonarQubePing,
+  handleSonarQubeComponentMeasures,
+  handleSonarQubeComponentsMeasures,
+  handleSonarQubeMeasuresHistory,
+  handleSonarQubeListQualityGates,
+  handleSonarQubeGetQualityGate,
+  handleSonarQubeQualityGateStatus,
+  handleSonarQubeGetSourceCode,
+  handleSonarQubeGetScmBlame,
+  handleSonarQubeHotspots,
+  handleSonarQubeHotspot,
+  handleSonarQubeUpdateHotspotStatus,
+  handleAddCommentToIssue,
+  handleAssignIssue,
+  handleConfirmIssue,
+  handleUnconfirmIssue,
+  handleResolveIssue,
+  handleReopenIssue,
+  handleSonarQubeComponents,
+  setElicitationManager,
+} from './handlers/index.js';
+import {
+  projectsToolSchema,
+  metricsToolSchema,
+  issuesToolSchema,
+  markIssueFalsePositiveToolSchema,
+  markIssueWontFixToolSchema,
+  markIssuesFalsePositiveToolSchema,
+  markIssuesWontFixToolSchema,
+  addCommentToIssueToolSchema,
+  assignIssueToolSchema,
+  confirmIssueToolSchema,
+  unconfirmIssueToolSchema,
+  resolveIssueToolSchema,
+  reopenIssueToolSchema,
+  systemHealthToolSchema,
+  systemStatusToolSchema,
+  systemPingToolSchema,
+  componentMeasuresToolSchema,
+  componentsMeasuresToolSchema,
+  measuresHistoryToolSchema,
+  qualityGatesToolSchema,
+  qualityGateToolSchema,
+  qualityGateStatusToolSchema,
+  sourceCodeToolSchema,
+  scmBlameToolSchema,
+  hotspotsToolSchema,
+  hotspotToolSchema,
+  updateHotspotStatusToolSchema,
+  componentsToolSchema,
+} from './schemas/index.js';
+
+// Type alias for parameters that can be string, array of strings, or undefined
+type StringOrArrayParam = string | string[] | undefined;
+
+const logger = createLogger('index');
+
+// Create elicitation manager instance
+const elicitationManager = createElicitationManager();
+
+// Set elicitation manager on handlers that need it
+setElicitationManager(elicitationManager);
+setSonarQubeElicitationManager(elicitationManager);
+
+// Re-export utilities for backward compatibility
+export { nullToUndefined, stringToNumberTransform } from './utils/transforms.js';
+export { mapToSonarQubeParams } from './utils/parameter-mappers.js';
+
+// Initialize MCP server
+export const mcpServer = new McpServer({
+  name: 'sonarqube-mcp-server',
+  version: SERVER_VERSION,
+});
+
+// Create the SonarQube client
+export const createDefaultClient = (): ISonarQubeClient => {
+  logger.debug('Creating default SonarQube client');
+  validateEnvironmentVariables();
+
+  // Use the environment-based factory function
+  const client = createSonarQubeClientFromEnv();
+
+  logger.info('SonarQube client created successfully', {
+    url: process.env.SONARQUBE_URL ?? 'https://sonarcloud.io',
+    organization: process.env.SONARQUBE_ORGANIZATION ?? 'not specified',
+  });
+
+  return client;
+};
+
+// Re-export resetDefaultClient for backward compatibility
+export { resetDefaultClient };
+
+// Re-export handlers for backward compatibility
+export {
+  handleSonarQubeProjects,
+  handleSonarQubeGetIssues,
+  handleMarkIssueFalsePositive,
+  handleMarkIssueWontFix,
+  handleMarkIssuesFalsePositive,
+  handleMarkIssuesWontFix,
+  handleSonarQubeGetMetrics,
+  handleSonarQubeGetHealth,
+  handleSonarQubeGetStatus,
+  handleSonarQubePing,
+  handleSonarQubeComponentMeasures,
+  handleSonarQubeComponentsMeasures,
+  handleSonarQubeMeasuresHistory,
+  handleSonarQubeListQualityGates,
+  handleSonarQubeGetQualityGate,
+  handleSonarQubeQualityGateStatus,
+  handleSonarQubeGetSourceCode,
+  handleSonarQubeGetScmBlame,
+  handleSonarQubeHotspots,
+  handleSonarQubeHotspot,
+  handleSonarQubeUpdateHotspotStatus,
+} from './handlers/index.js';
+
+// Helper function to parse JSON string arrays in parameters
+function parseArrayParameters(params: Record<string, unknown>, paramNames: string[]): void {
+  for (const key of paramNames) {
+    if (typeof params[key] === 'string') {
+      try {
+        const parsed = JSON.parse(params[key] as string);
+        if (Array.isArray(parsed)) {
+          params[key] = parsed;
+        }
+      } catch {
+        // Not valid JSON, keep as string for backward compatibility
+      }
+    }
+  }
+}
+
+// Lambda functions for the MCP tools
+/**
+ * Lambda function for projects tool
+ */
+export const projectsHandler = handleSonarQubeProjects;
+
+/**
+ * Lambda function for metrics tool
+ */
+export const metricsHandler = async (params: { page: number | null; page_size: number | null }) => {
+  return handleSonarQubeGetMetrics({
+    page: nullToUndefined(params.page),
+    pageSize: nullToUndefined(params.page_size),
+  });
+};
+
+/**
+ * Lambda function for issues tool
+ */
+export const issuesHandler = async (params: Record<string, unknown>) => {
+  // Parse JSON strings to arrays for array parameters
+  parseArrayParameters(params, [
+    'projects', 'component_keys', 'components', 'directories', 'files', 
+    'scopes', 'issues', 'severities', 'statuses', 'resolutions', 'types',
+    'clean_code_attribute_categories', 'impact_severities', 'impact_software_qualities',
+    'issue_statuses', 'rules', 'tags', 'assignees', 'authors', 'cwe',
+    'owasp_top10', 'owasp_top10_v2021', 'sans_top25', 'sonarsource_security',
+    'sonarsource_security_category', 'languages', 'facets', 'additional_fields'
+  ]);
+  
+  return handleSonarQubeGetIssues(mapToSonarQubeParams(params));
+};
+
+/**
+ * Lambda function for mark issue false positive tool
+ */
+export const markIssueFalsePositiveHandler = async (params: Record<string, unknown>) => {
+  return handleMarkIssueFalsePositive({
+    issueKey: params.issue_key as string,
+    comment: params.comment as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for mark issue won't fix tool
+ */
+export const markIssueWontFixHandler = async (params: Record<string, unknown>) => {
+  return handleMarkIssueWontFix({
+    issueKey: params.issue_key as string,
+    comment: params.comment as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for mark issues false positive (bulk) tool
+ */
+export const markIssuesFalsePositiveHandler = async (params: Record<string, unknown>) => {
+  return handleMarkIssuesFalsePositive({
+    issueKeys: params.issue_keys as string[],
+    comment: params.comment as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for mark issues won't fix (bulk) tool
+ */
+export const markIssuesWontFixHandler = async (params: Record<string, unknown>) => {
+  return handleMarkIssuesWontFix({
+    issueKeys: params.issue_keys as string[],
+    comment: params.comment as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for add comment to issue tool
+ */
+export const addCommentToIssueHandler = async (params: Record<string, unknown>) => {
+  return handleAddCommentToIssue({
+    issueKey: params.issue_key as string,
+    text: params.text as string,
+  });
+};
+
+/**
+ * Lambda function for assign issue tool
+ */
+export const assignIssueHandler = async (params: Record<string, unknown>) => {
+  return handleAssignIssue({
+    issueKey: params.issueKey as string,
+    assignee: params.assignee as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for confirm issue tool
+ */
+export const confirmIssueHandler = async (params: Record<string, unknown>) => {
+  return handleConfirmIssue({
+    issueKey: params.issue_key as string,
+    comment: params.comment as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for unconfirm issue tool
+ */
+export const unconfirmIssueHandler = async (params: Record<string, unknown>) => {
+  return handleUnconfirmIssue({
+    issueKey: params.issue_key as string,
+    comment: params.comment as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for resolve issue tool
+ */
+export const resolveIssueHandler = async (params: Record<string, unknown>) => {
+  return handleResolveIssue({
+    issueKey: params.issue_key as string,
+    comment: params.comment as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for reopen issue tool
+ */
+export const reopenIssueHandler = async (params: Record<string, unknown>) => {
+  return handleReopenIssue({
+    issueKey: params.issue_key as string,
+    comment: params.comment as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for system_health tool
+ */
+export const healthHandler = handleSonarQubeGetHealth;
+
+/**
+ * Lambda function for system_status tool
+ */
+export const statusHandler = handleSonarQubeGetStatus;
+
+/**
+ * Lambda function for system_ping tool
+ */
+export const pingHandler = handleSonarQubePing;
+
+/**
+ * Lambda function for measures_component tool
+ */
+export const componentMeasuresHandler = async (params: Record<string, unknown>) => {
+  // Parse JSON strings to arrays for array parameters
+  parseArrayParameters(params, ['metric_keys', 'additional_fields']);
+  
+  return handleSonarQubeComponentMeasures({
+    component: params.component as string,
+    metricKeys: ensureStringArray(params.metric_keys as StringOrArrayParam),
+    additionalFields: params.additional_fields as string[] | undefined,
+    branch: params.branch as string | undefined,
+    pullRequest: params.pull_request as string | undefined,
+    period: params.period as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for measures_components tool
+ */
+export const componentsMeasuresHandler = async (params: Record<string, unknown>) => {
+  // Parse JSON strings to arrays for array parameters
+  parseArrayParameters(params, ['component_keys', 'metric_keys', 'additional_fields']);
+  
+  return handleSonarQubeComponentsMeasures({
+    componentKeys: ensureStringArray(params.component_keys as StringOrArrayParam),
+    metricKeys: ensureStringArray(params.metric_keys as StringOrArrayParam),
+    additionalFields: params.additional_fields as string[] | undefined,
+    branch: params.branch as string | undefined,
+    pullRequest: params.pull_request as string | undefined,
+    period: params.period as string | undefined,
+    page: nullToUndefined(params.page) as number | undefined,
+    pageSize: nullToUndefined(params.page_size) as number | undefined,
+  });
+};
+
+/**
+ * Lambda function for measures_history tool
+ */
+export const measuresHistoryHandler = async (params: Record<string, unknown>) => {
+  // Parse JSON strings to arrays for array parameters
+  parseArrayParameters(params, ['metrics']);
+  
+  return handleSonarQubeMeasuresHistory({
+    component: params.component as string,
+    metrics: ensureStringArray(params.metrics as StringOrArrayParam),
+    from: params.from as string | undefined,
+    to: params.to as string | undefined,
+    branch: params.branch as string | undefined,
+    pullRequest: params.pull_request as string | undefined,
+    page: nullToUndefined(params.page) as number | undefined,
+    pageSize: nullToUndefined(params.page_size) as number | undefined,
+  });
+};
+
+/**
+ * Lambda function for quality_gates tool
+ */
+export const qualityGatesHandler = handleSonarQubeListQualityGates;
+
+/**
+ * Lambda function for quality_gate tool
+ */
+export const qualityGateHandler = async (params: Record<string, unknown>) => {
+  return handleSonarQubeGetQualityGate({
+    id: params.id as string,
+  });
+};
+
+/**
+ * Lambda function for quality_gate_status tool
+ */
+export const qualityGateStatusHandler = async (params: Record<string, unknown>) => {
+  return handleSonarQubeQualityGateStatus({
+    projectKey: params.project_key as string,
+    branch: params.branch as string | undefined,
+    pullRequest: params.pull_request as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for source_code tool
+ */
+export const sourceCodeHandler = async (params: Record<string, unknown>) => {
+  return handleSonarQubeGetSourceCode({
+    key: params.key as string,
+    from: nullToUndefined(params.from) as number | undefined,
+    to: nullToUndefined(params.to) as number | undefined,
+    branch: params.branch as string | undefined,
+    pullRequest: params.pull_request as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for scm_blame tool
+ */
+export const scmBlameHandler = async (params: Record<string, unknown>) => {
+  return handleSonarQubeGetScmBlame({
+    key: params.key as string,
+    from: nullToUndefined(params.from) as number | undefined,
+    to: nullToUndefined(params.to) as number | undefined,
+    branch: params.branch as string | undefined,
+    pullRequest: params.pull_request as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for search_hotspots tool
+ */
+export const hotspotsHandler = async (params: Record<string, unknown>) => {
+  // Parse JSON strings to arrays for array parameters
+  parseArrayParameters(params, ['files']);
+  
+  return handleSonarQubeHotspots({
+    projectKey: params.project_key as string | undefined,
+    branch: params.branch as string | undefined,
+    pullRequest: params.pull_request as string | undefined,
+    status: params.status as HotspotSearchParams['status'],
+    resolution: params.resolution as HotspotSearchParams['resolution'],
+    files: nullToUndefined(params.files) as string[] | undefined,
+    assignedToMe: nullToUndefined(params.assigned_to_me) as boolean | undefined,
+    sinceLeakPeriod: nullToUndefined(params.since_leak_period) as boolean | undefined,
+    inNewCodePeriod: nullToUndefined(params.in_new_code_period) as boolean | undefined,
+    page: nullToUndefined(params.page) as number | undefined,
+    pageSize: nullToUndefined(params.page_size) as number | undefined,
+  });
+};
+
+/**
+ * Lambda function for get_hotspot_details tool
+ */
+export const hotspotHandler = async (params: Record<string, unknown>) => {
+  return handleSonarQubeHotspot(params.hotspot_key as string);
+};
+
+/**
+ * Lambda function for update_hotspot_status tool
+ */
+export const updateHotspotStatusHandler = async (params: Record<string, unknown>) => {
+  return handleSonarQubeUpdateHotspotStatus({
+    hotspot: params.hotspot_key as string,
+    status: params.status as HotspotStatusUpdateParams['status'],
+    resolution: params.resolution as HotspotStatusUpdateParams['resolution'],
+    comment: params.comment as string | undefined,
+  });
+};
+
+/**
+ * Lambda function for components tool
+ */
+export const componentsHandler = async (params: Record<string, unknown>) => {
+  return handleSonarQubeComponents({
+    query: params.query as string | undefined,
+    qualifiers: params.qualifiers as ComponentQualifier[] | undefined,
+    language: params.language as string | undefined,
+    component: params.component as string | undefined,
+    strategy: params.strategy as 'all' | 'children' | 'leaves' | undefined,
+    key: params.key as string | undefined,
+    asc: params.asc as boolean | undefined,
+    ps: params.ps as number | undefined,
+    p: params.p as number | undefined,
+    branch: params.branch as string | undefined,
+    pullRequest: params.pullRequest as string | undefined,
+  });
+};
+
+// Wrapper functions for MCP registration that don't expose the client parameter
+export const projectsMcpHandler = (params: Record<string, unknown>) => projectsHandler(params);
+export const metricsMcpHandler = (params: Record<string, unknown>) =>
+  metricsHandler(params as { page: number | null; page_size: number | null });
+export const issuesMcpHandler = (params: Record<string, unknown>) => issuesHandler(params);
+export const markIssueFalsePositiveMcpHandler = (params: Record<string, unknown>) =>
+  markIssueFalsePositiveHandler(params);
+export const markIssueWontFixMcpHandler = (params: Record<string, unknown>) =>
+  markIssueWontFixHandler(params);
+export const markIssuesFalsePositiveMcpHandler = (params: Record<string, unknown>) =>
+  markIssuesFalsePositiveHandler(params);
+export const markIssuesWontFixMcpHandler = (params: Record<string, unknown>) =>
+  markIssuesWontFixHandler(params);
+export const addCommentToIssueMcpHandler = (params: Record<string, unknown>) =>
+  addCommentToIssueHandler(params);
+export const assignIssueMcpHandler = (params: Record<string, unknown>) =>
+  assignIssueHandler(params);
+export const confirmIssueMcpHandler = (params: Record<string, unknown>) =>
+  confirmIssueHandler(params);
+export const unconfirmIssueMcpHandler = (params: Record<string, unknown>) =>
+  unconfirmIssueHandler(params);
+export const resolveIssueMcpHandler = (params: Record<string, unknown>) =>
+  resolveIssueHandler(params);
+export const reopenIssueMcpHandler = (params: Record<string, unknown>) =>
+  reopenIssueHandler(params);
+export const healthMcpHandler = () => healthHandler();
+export const statusMcpHandler = () => statusHandler();
+export const pingMcpHandler = () => pingHandler();
+export const componentMeasuresMcpHandler = (params: Record<string, unknown>) =>
+  componentMeasuresHandler(params);
+export const componentsMeasuresMcpHandler = (params: Record<string, unknown>) =>
+  componentsMeasuresHandler(params);
+export const measuresHistoryMcpHandler = (params: Record<string, unknown>) =>
+  measuresHistoryHandler(params);
+export const qualityGatesMcpHandler = () => qualityGatesHandler();
+export const qualityGateMcpHandler = (params: Record<string, unknown>) =>
+  qualityGateHandler(params);
+export const qualityGateStatusMcpHandler = (params: Record<string, unknown>) =>
+  qualityGateStatusHandler(params);
+export const sourceCodeMcpHandler = (params: Record<string, unknown>) => sourceCodeHandler(params);
+export const scmBlameMcpHandler = (params: Record<string, unknown>) => scmBlameHandler(params);
+export const hotspotsMcpHandler = (params: Record<string, unknown>) => hotspotsHandler(params);
+export const hotspotMcpHandler = (params: Record<string, unknown>) => hotspotHandler(params);
+export const updateHotspotStatusMcpHandler = (params: Record<string, unknown>) =>
+  updateHotspotStatusHandler(params);
+export const componentsMcpHandler = (params: Record<string, unknown>) => componentsHandler(params);
+
+// Register SonarQube tools
+mcpServer.tool(
+  'projects',
+  'List all SonarQube projects with metadata (requires admin permissions)',
+  projectsToolSchema,
+  {
+    title: 'List Projects',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  projectsMcpHandler
+);
+
+mcpServer.tool(
+  'metrics',
+  'Get available metrics from SonarQube',
+  metricsToolSchema,
+  {
+    title: 'Get Metrics',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  metricsMcpHandler
+);
+
+mcpServer.tool(
+  'issues',
+  'Search and filter SonarQube issues by severity, status, assignee, tag, file path, directory, scope, and more. Critical for dashboards, targeted clean-up sprints, security audits, and regression testing. Supports faceted search for aggregations.',
+  issuesToolSchema,
+  {
+    title: 'Search Issues',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  issuesMcpHandler
+);
+
+mcpServer.tool(
+  'markIssueFalsePositive',
+  'Mark an issue as false positive',
+  markIssueFalsePositiveToolSchema,
+  {
+    title: 'Mark Issue False Positive',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  markIssueFalsePositiveMcpHandler
+);
+
+mcpServer.tool(
+  'markIssueWontFix',
+  "Mark an issue as won't fix",
+  markIssueWontFixToolSchema,
+  {
+    title: "Mark Issue Won't Fix",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  markIssueWontFixMcpHandler
+);
+
+mcpServer.tool(
+  'markIssuesFalsePositive',
+  'Mark multiple issues as false positive (bulk operation)',
+  markIssuesFalsePositiveToolSchema,
+  {
+    title: 'Mark Issues False Positive',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  markIssuesFalsePositiveMcpHandler
+);
+
+mcpServer.tool(
+  'markIssuesWontFix',
+  "Mark multiple issues as won't fix (bulk operation)",
+  markIssuesWontFixToolSchema,
+  {
+    title: "Mark Issues Won't Fix",
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  markIssuesWontFixMcpHandler
+);
+
+mcpServer.tool(
+  'addCommentToIssue',
+  'Add a comment to a SonarQube issue',
+  addCommentToIssueToolSchema,
+  {
+    title: 'Add Comment to Issue',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  addCommentToIssueMcpHandler
+);
+
+mcpServer.tool(
+  'assignIssue',
+  'Assign a SonarQube issue to a user or unassign it',
+  assignIssueToolSchema,
+  {
+    title: 'Assign Issue',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  assignIssueMcpHandler
+);
+
+mcpServer.tool(
+  'confirmIssue',
+  'Confirm a SonarQube issue',
+  confirmIssueToolSchema,
+  {
+    title: 'Confirm Issue',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  confirmIssueMcpHandler
+);
+
+mcpServer.tool(
+  'unconfirmIssue',
+  'Unconfirm a SonarQube issue',
+  unconfirmIssueToolSchema,
+  {
+    title: 'Unconfirm Issue',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  unconfirmIssueMcpHandler
+);
+
+mcpServer.tool(
+  'resolveIssue',
+  'Resolve a SonarQube issue',
+  resolveIssueToolSchema,
+  {
+    title: 'Resolve Issue',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: true,
+    openWorldHint: true,
+  },
+  resolveIssueMcpHandler
+);
+
+mcpServer.tool(
+  'reopenIssue',
+  'Reopen a SonarQube issue',
+  reopenIssueToolSchema,
+  {
+    title: 'Reopen Issue',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  reopenIssueMcpHandler
+);
+
+// Register system API tools
+mcpServer.tool(
+  'system_health',
+  'Get the health status of the SonarQube instance',
+  systemHealthToolSchema,
+  {
+    title: 'Get System Health',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  healthMcpHandler
+);
+
+mcpServer.tool(
+  'system_status',
+  'Get the status of the SonarQube instance',
+  systemStatusToolSchema,
+  {
+    title: 'Get System Status',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  statusMcpHandler
+);
+
+mcpServer.tool(
+  'system_ping',
+  'Ping the SonarQube instance to check if it is up',
+  systemPingToolSchema,
+  {
+    title: 'Ping System',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  pingMcpHandler
+);
+
+// Register measures API tools
+mcpServer.tool(
+  'measures_component',
+  'Get measures for a specific component',
+  componentMeasuresToolSchema,
+  {
+    title: 'Get Component Measures',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  componentMeasuresMcpHandler
+);
+
+mcpServer.tool(
+  'measures_components',
+  'Get measures for multiple components',
+  componentsMeasuresToolSchema,
+  {
+    title: 'Get Components Measures',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  componentsMeasuresMcpHandler
+);
+
+mcpServer.tool(
+  'measures_history',
+  'Get measures history for a component',
+  measuresHistoryToolSchema,
+  {
+    title: 'Get Measures History',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  measuresHistoryMcpHandler
+);
+
+// Register Quality Gates API tools
+mcpServer.tool(
+  'quality_gates',
+  'List available quality gates',
+  qualityGatesToolSchema,
+  {
+    title: 'List Quality Gates',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  qualityGatesMcpHandler
+);
+
+mcpServer.tool(
+  'quality_gate',
+  'Get quality gate conditions',
+  qualityGateToolSchema,
+  {
+    title: 'Get Quality Gate',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  qualityGateMcpHandler
+);
+
+mcpServer.tool(
+  'quality_gate_status',
+  'Get project quality gate status',
+  qualityGateStatusToolSchema,
+  {
+    title: 'Get Quality Gate Status',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  qualityGateStatusMcpHandler
+);
+
+// Register Source Code API tools
+mcpServer.tool(
+  'source_code',
+  'View source code with issues highlighted',
+  sourceCodeToolSchema,
+  {
+    title: 'View Source Code',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  sourceCodeMcpHandler
+);
+
+mcpServer.tool(
+  'scm_blame',
+  'Get SCM blame information for source code',
+  scmBlameToolSchema,
+  {
+    title: 'Get SCM Blame',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  scmBlameMcpHandler
+);
+
+// Register Security Hotspot tools
+mcpServer.tool(
+  'hotspots',
+  'Search for security hotspots with filtering options',
+  hotspotsToolSchema,
+  {
+    title: 'Search Hotspots',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  hotspotsMcpHandler
+);
+
+mcpServer.tool(
+  'hotspot',
+  'Get detailed information about a specific security hotspot',
+  hotspotToolSchema,
+  {
+    title: 'Get Hotspot Details',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  hotspotMcpHandler
+);
+
+mcpServer.tool(
+  'update_hotspot_status',
+  'Update the status of a security hotspot (requires appropriate permissions)',
+  updateHotspotStatusToolSchema,
+  {
+    title: 'Update Hotspot Status',
+    readOnlyHint: false,
+    destructiveHint: false,
+    idempotentHint: false,
+    openWorldHint: true,
+  },
+  updateHotspotStatusMcpHandler
+);
+
+// Register Components tool
+mcpServer.tool(
+  'components',
+  'Search and navigate SonarQube components (projects, directories, files). Supports text search, filtering by type/language, and tree navigation',
+  componentsToolSchema,
+  {
+    title: 'Search Components',
+    readOnlyHint: true,
+    destructiveHint: false,
+    openWorldHint: true,
+  },
+  componentsMcpHandler
+);
+
+// Only start the server if not in test mode
+/* istanbul ignore if */
+if (process.env.NODE_ENV !== 'test') {
+  logger.info('Starting SonarQube MCP server', {
+    ...VERSION_INFO,
+    logFile: process.env.LOG_FILE ?? 'not configured',
+    logLevel: process.env.LOG_LEVEL ?? 'DEBUG',
+    elicitation: elicitationManager.isEnabled() ? 'enabled' : 'disabled',
+  });
+
+  // Initialize permission manager before starting the server
+  await getPermissionManager();
+  logger.info('Permission manager initialized');
+
+  // Create transport using the factory
+  const transport = TransportFactory.createFromEnvironment();
+  logger.info(`Using ${transport.getName()} transport`);
+
+  // Set the underlying Server instance on the elicitation manager
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  elicitationManager.setServer((mcpServer as any).server as Server);
+
+  // Connect the transport to the MCP server
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  await transport.connect((mcpServer as any).server as Server);
+
+  logger.info('SonarQube MCP server started successfully', {
+    mcpProtocolInfo: 'Protocol version will be negotiated with client during initialization',
+  });
+}
+
+// nullToUndefined is already exported at line 33

--- a/mcp_sonar/src/schemas/common.ts
+++ b/mcp_sonar/src/schemas/common.ts
@@ -1,0 +1,64 @@
+import { z } from 'zod';
+import { numberOrStringToString, parseJsonStringArray } from '../utils/transforms.js';
+
+/**
+ * Common schemas used across multiple domains
+ */
+
+// Severity schemas
+export const severitySchema = z
+  .enum(['INFO', 'MINOR', 'MAJOR', 'CRITICAL', 'BLOCKER'])
+  .nullable()
+  .optional();
+
+export const severitiesSchema = z
+  .union([z.array(z.enum(['INFO', 'MINOR', 'MAJOR', 'CRITICAL', 'BLOCKER'])), z.string()])
+  .nullable()
+  .optional();
+
+// Status schemas
+export const statusSchema = z
+  .union([z.array(z.enum(['OPEN', 'CONFIRMED', 'REOPENED', 'RESOLVED', 'CLOSED'])), z.string()])
+  .nullable()
+  .optional();
+
+// Resolution schemas
+export const resolutionSchema = z
+  .union([z.array(z.enum(['FALSE-POSITIVE', 'WONTFIX', 'FIXED', 'REMOVED'])), z.string()])
+  .nullable()
+  .optional();
+
+// Type schemas
+export const typeSchema = z
+  .union([z.array(z.enum(['CODE_SMELL', 'BUG', 'VULNERABILITY', 'SECURITY_HOTSPOT'])), z.string()])
+  .nullable()
+  .optional();
+
+// Clean Code taxonomy schemas
+export const cleanCodeAttributeCategoriesSchema = z
+  .union([z.array(z.enum(['ADAPTABLE', 'CONSISTENT', 'INTENTIONAL', 'RESPONSIBLE'])), z.string()])
+  .nullable()
+  .optional();
+
+export const impactSeveritiesSchema = z
+  .union([z.array(z.enum(['HIGH', 'MEDIUM', 'LOW'])), z.string()])
+  .nullable()
+  .optional();
+
+export const impactSoftwareQualitiesSchema = z
+  .union([z.array(z.enum(['MAINTAINABILITY', 'RELIABILITY', 'SECURITY'])), z.string()])
+  .nullable()
+  .optional();
+
+// Pull request schema - accepts either string or number and converts to string
+export const pullRequestSchema = z
+  .union([z.string(), z.number()])
+  .optional()
+  .transform(numberOrStringToString);
+
+// Pull request schema with nullable - for schemas that allow null values
+export const pullRequestNullableSchema = z
+  .union([z.string(), z.number()])
+  .nullable()
+  .optional()
+  .transform(numberOrStringToString);

--- a/mcp_sonar/src/schemas/issues.ts
+++ b/mcp_sonar/src/schemas/issues.ts
@@ -1,0 +1,308 @@
+import { z } from 'zod';
+import { stringToNumberTransform, parseJsonStringArray } from '../utils/transforms.js';
+import {
+  severitySchema,
+  severitiesSchema,
+  statusSchema,
+  resolutionSchema,
+  typeSchema,
+  cleanCodeAttributeCategoriesSchema,
+  impactSeveritiesSchema,
+  impactSoftwareQualitiesSchema,
+  pullRequestNullableSchema,
+} from './common.js';
+
+/**
+ * Schema for mark issue false positive tool
+ */
+export const markIssueFalsePositiveToolSchema = {
+  issue_key: z.string().describe('The key of the issue to mark as false positive'),
+  comment: z
+    .string()
+    .optional()
+    .describe('Optional comment explaining why this is a false positive'),
+};
+
+/**
+ * Schema for mark issue won\'t fix tool
+ */
+export const markIssueWontFixToolSchema = {
+  issue_key: z.string().describe("The key of the issue to mark as won't fix"),
+  comment: z.string().optional().describe("Optional comment explaining why this won't be fixed"),
+};
+
+/**
+ * Schema for mark issues false positive (bulk) tool
+ */
+export const markIssuesFalsePositiveToolSchema = {
+  issue_keys: z
+    .array(z.string())
+    .min(1, 'At least one issue key is required')
+    .describe('Array of issue keys to mark as false positive'),
+  comment: z
+    .string()
+    .optional()
+    .describe('Optional comment explaining why these are false positives'),
+};
+
+/**
+ * Schema for mark issues won\'t fix (bulk) tool
+ */
+export const markIssuesWontFixToolSchema = {
+  issue_keys: z
+    .array(z.string())
+    .min(1, 'At least one issue key is required')
+    .describe("Array of issue keys to mark as won't fix"),
+  comment: z.string().optional().describe("Optional comment explaining why these won't be fixed"),
+};
+
+/**
+ * Schema for add comment to issue tool
+ */
+export const addCommentToIssueToolSchema = {
+  issue_key: z
+    .string()
+    .min(1, 'Issue key is required')
+    .describe('The key of the issue to add a comment to'),
+  text: z
+    .string()
+    .min(1, 'Comment text is required')
+    .describe('The comment text to add. Supports markdown formatting for rich text content'),
+};
+
+/**
+ * Schema for assign issue tool
+ */
+export const assignIssueToolSchema = {
+  issueKey: z.string().min(1, 'Issue key is required').describe('The key of the issue to assign'),
+  assignee: z
+    .string()
+    .optional()
+    .describe('The username of the assignee. Leave empty to unassign the issue'),
+};
+
+/**
+ * Schema for confirm issue tool
+ */
+export const confirmIssueToolSchema = {
+  issue_key: z.string().describe('The key of the issue to confirm'),
+  comment: z
+    .string()
+    .optional()
+    .describe('Optional comment explaining why this issue is confirmed'),
+};
+
+/**
+ * Schema for unconfirm issue tool
+ */
+export const unconfirmIssueToolSchema = {
+  issue_key: z.string().describe('The key of the issue to unconfirm'),
+  comment: z
+    .string()
+    .optional()
+    .describe('Optional comment explaining why this issue needs further investigation'),
+};
+
+/**
+ * Schema for resolve issue tool
+ */
+export const resolveIssueToolSchema = {
+  issue_key: z.string().describe('The key of the issue to resolve'),
+  comment: z.string().optional().describe('Optional comment explaining how the issue was resolved'),
+};
+
+/**
+ * Schema for reopen issue tool
+ */
+export const reopenIssueToolSchema = {
+  issue_key: z.string().describe('The key of the issue to reopen'),
+  comment: z
+    .string()
+    .optional()
+    .describe('Optional comment explaining why the issue is being reopened'),
+};
+
+/**
+ * Schema for issues tool
+ */
+export const issuesToolSchema = {
+  // Component filters (backward compatible)
+  project_key: z.string().optional().describe('Single project key for backward compatibility'), // Made optional to support projects array
+  projects: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional()
+    .describe('Filter by project keys'),
+  component_keys: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional()
+    .describe(
+      'Filter by component keys (file paths, directories, or modules). Use this to filter issues by specific files or folders'
+    ),
+  components: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional()
+    .describe('Alias for component_keys - filter by file paths, directories, or modules'),
+  on_component_only: z
+    .union([z.boolean(), z.string().transform((val) => val === 'true')])
+    .nullable()
+    .optional()
+    .describe('Return only issues on the specified components, not on their sub-components'),
+  directories: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional()
+    .describe('Filter by directory paths'),
+  files: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional()
+    .describe('Filter by specific file paths'),
+  scopes: z
+    .union([z.array(z.enum(['MAIN', 'TEST', 'OVERALL'])), z.string()])
+    .nullable()
+    .optional()
+    .describe('Filter by issue scopes (MAIN, TEST, OVERALL)'),
+
+  // Branch and PR support
+  branch: z.string().nullable().optional(),
+  pull_request: pullRequestNullableSchema,
+
+  // Issue filters
+  issues: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional(),
+  severity: severitySchema, // Deprecated single value
+  severities: severitiesSchema, // New array support
+  statuses: statusSchema,
+  resolutions: resolutionSchema,
+  resolved: z
+    .union([z.boolean(), z.string().transform((val) => val === 'true')])
+    .nullable()
+    .optional(),
+  types: typeSchema,
+
+  // Clean Code taxonomy (SonarQube 10.x+)
+  clean_code_attribute_categories: cleanCodeAttributeCategoriesSchema,
+  impact_severities: impactSeveritiesSchema,
+  impact_software_qualities: impactSoftwareQualitiesSchema,
+  issue_statuses: statusSchema, // New issue status values
+
+  // Rules and tags
+  rules: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional()
+    .describe('Filter by rule keys'),
+  tags: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional()
+    .describe(
+      'Filter by issue tags. Essential for security audits, regression testing, and categorized analysis'
+    ),
+
+  // Date filters
+  created_after: z.string().nullable().optional(),
+  created_before: z.string().nullable().optional(),
+  created_at: z.string().nullable().optional(),
+  created_in_last: z.string().nullable().optional(),
+
+  // Assignment
+  assigned: z
+    .union([z.boolean(), z.string().transform((val) => val === 'true')])
+    .nullable()
+    .optional()
+    .describe('Filter to only assigned (true) or unassigned (false) issues'),
+  assignees: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional()
+    .describe(
+      'Filter by assignee logins. Critical for targeted clean-up sprints and workload analysis'
+    ),
+  author: z.string().nullable().optional().describe('Filter by single issue author'), // Single author
+  authors: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional()
+    .describe('Filter by multiple issue authors'), // Multiple authors
+
+  // Security standards
+  cwe: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional(),
+  owasp_top10: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional(),
+  owasp_top10_v2021: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional(), // New 2021 version
+  sans_top25: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional(),
+  sonarsource_security: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional(),
+  sonarsource_security_category: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional(),
+
+  // Languages
+  languages: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional(),
+
+  // Facets
+  facets: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional()
+    .describe(
+      'Enable faceted search for aggregations. Critical for dashboards. Available facets: severities, statuses, resolutions, rules, tags, types, authors, assignees, languages, etc.'
+    ),
+  facet_mode: z
+    .enum(['effort', 'count'])
+    .nullable()
+    .optional()
+    .describe(
+      'Mode for facet computation: count (number of issues) or effort (remediation effort)'
+    ),
+
+  // New code
+  since_leak_period: z
+    .union([z.boolean(), z.string().transform((val) => val === 'true')])
+    .nullable()
+    .optional(),
+  in_new_code_period: z
+    .union([z.boolean(), z.string().transform((val) => val === 'true')])
+    .nullable()
+    .optional(),
+
+  // Sorting
+  s: z.string().nullable().optional(), // Sort field
+  asc: z
+    .union([z.boolean(), z.string().transform((val) => val === 'true')])
+    .nullable()
+    .optional(), // Sort direction
+
+  // Response optimization
+  additional_fields: z
+    .union([z.array(z.string()), z.string()])
+    .nullable()
+    .optional(),
+
+  // Pagination
+  page: z.string().optional().transform(stringToNumberTransform),
+  page_size: z.string().optional().transform(stringToNumberTransform),
+};


### PR DESCRIPTION
  ## Fix MCP Array Serialization Schema Issue

  ### Problem
  MCP clients were receiving incomplete schemas for array parameters, causing validation errors when sending JSON-serialized
   arrays. The Zod transform functions were not being preserved during the Zod-to-JSON-Schema conversion, resulting in the
  string option being dropped from union types.

  ### Solution
  - Removed `.transform()` functions from array schemas in `common.ts` and `issues.ts`
  - Added JSON string parsing logic in handlers before schema validation
  - Created a helper function `parseArrayParameters()` to handle JSON string to array conversion

  ### Changes
  - Modified schema definitions to remove transforms while keeping union types
  - Updated handlers to parse JSON strings before passing to validation
  - Maintains backward compatibility by accepting both native arrays and JSON string arrays

  ### Testing
  The fix ensures that:
  - MCP clients see the correct schema with both array and string options
  - JSON strings like `'["CRITICAL", "BLOCKER"]'` are properly parsed to arrays
  - Native arrays continue to work as before