### PR TITLE
Potential fix for code scanning alert no. 12: Use of externally-controlled format string

### DIFF
--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -498,7 +498,10 @@ export class HttpTransport implements ITransport {
         if (err) {
           // Use explicit string concatenation to avoid format string security warnings
           console.error(
-            '[' + new Date().toISOString() + '] ' + method + ' ' + path + ' - Error:',
+            '[%s] %s %s - Error: %s',
+            new Date().toISOString(),
+            method,
+            path,
             err
           );
         }

--- a/src/transports/http.ts
+++ b/src/transports/http.ts
@@ -497,13 +497,7 @@ export class HttpTransport implements ITransport {
       next = function (err?: unknown) {
         if (err) {
           // Use explicit string concatenation to avoid format string security warnings
-          console.error(
-            '[%s] %s %s - Error: %s',
-            new Date().toISOString(),
-            method,
-            path,
-            err
-          );
+          console.error('[%s] %s %s - Error: %s', new Date().toISOString(), method, path, err);
         }
         return originalNext(err);
       } as NextFunction;


### PR DESCRIPTION
Potential fix for [https://github.com/sapientpants/sonarqube-mcp-server/security/code-scanning/12](https://github.com/sapientpants/sonarqube-mcp-server/security/code-scanning/12)

To fix the issue, we will replace the string concatenation on line 501 with a safer approach using `util.format` or a similar method that explicitly specifies placeholders (`%s`) for untrusted data. This ensures that the untrusted `path` value is treated as a string and cannot introduce unexpected behavior. Additionally, we will ensure that the `method` and `path` variables are passed as arguments to the formatter, rather than being directly embedded in the string.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
