### PR TITLE
fix: resolve SonarQube issue S6551 in tracing.ts

### DIFF
--- a/src/monitoring/__tests__/tracing-advanced.test.ts
+++ b/src/monitoring/__tests__/tracing-advanced.test.ts
@@ -254,7 +254,7 @@ describe('Tracing Advanced Tests', () => {
         stringAttr: 'value',
         numberAttr: 42,
         booleanAttr: true,
-        objectAttr: '[object Object]', // String() converts objects this way
+        objectAttr: '{"nested":"object"}', // JSON.stringify converts objects this way
       });
     });
 

--- a/src/monitoring/tracing.ts
+++ b/src/monitoring/tracing.ts
@@ -281,7 +281,7 @@ export function addSpanEvent(name: string, attributes?: Record<string, unknown>)
         if (typeof value === 'string' || typeof value === 'number' || typeof value === 'boolean') {
           cleanedAttributes[key] = value;
         } else if (value != null) {
-          cleanedAttributes[key] = String(value);
+          cleanedAttributes[key] = JSON.stringify(value);
         }
       }
       span.addEvent(name, cleanedAttributes);


### PR DESCRIPTION
Fixes SonarQube issue S6551 by replacing String(value) with JSON.stringify(value) in addSpanEvent function. This ensures proper object serialization for debugging and makes the function consistent with addSpanAttributes. All tests pass.