### PR TITLE
chore: prepare release v1.7.2

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.2] - 2025-07-31
+
+### Changed
+- Cleaned up remaining HTTP/SSE transport references in documentation and code comments
+- Updated security documentation to reflect enterprise features handled by MCP gateways
+- Removed obsolete API reference documentation that was specific to HTTP transport
+
+### Removed
+- Removed `docs/api-reference.md` as it contained HTTP-specific content no longer relevant for stdio-only server
+
 ## [1.7.1] - 2025-07-30
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonarqube-mcp-server",
-  "version": "1.7.1",
+  "version": "1.7.2",
   "description": "Model Context Protocol server for SonarQube",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Release v1.7.2

This patch release completes the cleanup of HTTP/SSE transport references following the simplification to stdio-only transport.

### Changes
- Cleaned up remaining HTTP/SSE transport references in documentation and code comments
- Updated security documentation to reflect enterprise features handled by MCP gateways
- Removed obsolete API reference documentation that was specific to HTTP transport

### Removed
- Removed `docs/api-reference.md` as it contained HTTP-specific content no longer relevant for stdio-only server

### Testing
- All tests pass with 92.32% code coverage
- CI/CD pipeline validation pending

🤖 Generated with [Claude Code](https://claude.ai/code)