### PR TITLE
chore: prepare release v1.7.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [1.7.5] - 2025-08-18
+
+### Changed
+- Updated dependencies to latest versions:
+  - @modelcontextprotocol/sdk: 1.17.2 → 1.17.3
+  - @types/node: 24.2.1 → 24.3.0
+  - @typescript-eslint/eslint-plugin: 8.39.0 → 8.39.1
+  - @typescript-eslint/parser: 8.39.0 → 8.39.1
+  - nock: 14.0.9 → 14.0.10
+
 ## [1.7.4] - 2025-08-11
 
 ### Changed

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "sonarqube-mcp-server",
-  "version": "1.7.4",
+  "version": "1.7.5",
   "description": "Model Context Protocol server for SonarQube",
   "type": "module",
   "main": "dist/index.js",


### PR DESCRIPTION
## Summary
- Update version from 1.7.4 to 1.7.5
- Update CHANGELOG.md with dependency updates

## Changes
This release includes the following dependency updates that were already merged in PR #265:
- @modelcontextprotocol/sdk: 1.17.2 → 1.17.3
- @types/node: 24.2.1 → 24.3.0
- @typescript-eslint/eslint-plugin: 8.39.0 → 8.39.1
- @typescript-eslint/parser: 8.39.0 → 8.39.1
- nock: 14.0.9 → 14.0.10

## Test plan
[x] Dependencies updated and tested in PR #265
[x] CI/CD passes
[x] Version bumped correctly
[x] CHANGELOG updated

🤖 Generated with [Claude Code](https://claude.ai/code)