### PR TITLE
chore: downgrade pnpm from 10.17.1 to 10.17.0

### DIFF
--- a/.changeset/integrate-agentic-toolchain.md
+++ b/.changeset/integrate-agentic-toolchain.md
@@ -15,7 +15,7 @@ feat: integrate agentic-node-ts-starter toolchain and update dependencies
 
 ## Dependency Updates
 
-- Updated pnpm from 10.7.1 to 10.17.1 across all configuration files
+- Updated pnpm from 10.7.1 to 10.17.0 across all configuration files
 - Updated Node.js requirement from 20 to 22 in documentation and Docker
 - Ensures compatibility with latest toolchain versions
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -101,7 +101,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.17.1 # Pinned: Must match packageManager in package.json
+          version: 10.17.0 # Pinned: Must match packageManager in package.json
           run_install: false # Dependencies installed separately for caching
           standalone: true # Faster installation method
 

--- a/.github/workflows/pr.yml
+++ b/.github/workflows/pr.yml
@@ -95,7 +95,7 @@ jobs:
       - name: Install pnpm
         uses: pnpm/action-setup@v4
         with:
-          version: 10.17.1 # Pinned: Match package.json packageManager
+          version: 10.17.0 # Pinned: Match package.json packageManager
           run_install: false
           standalone: true
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -19,7 +19,7 @@ on:
 
 # Global environment variables for consistency
 env:
-  PNPM_VERSION: 10.17.1 # Pinned: Must match packageManager in package.json
+  PNPM_VERSION: 10.17.0 # Pinned: Must match packageManager in package.json
   NODE_VERSION: 22 # Pinned: Must match engines.node in package.json
 
 # SECURITY: Minimal required permissions

--- a/.github/workflows/reusable-security.yml
+++ b/.github/workflows/reusable-security.yml
@@ -17,7 +17,7 @@ on:
       pnpm-version:
         description: 'pnpm version (should match package.json packageManager)'
         type: string
-        default: '10.17.1' # UPDATE: When upgrading pnpm
+        default: '10.17.0' # UPDATE: When upgrading pnpm
       run-codeql:
         description: 'Run CodeQL static analysis for security vulnerabilities'
         type: boolean

--- a/.github/workflows/reusable-setup.yml
+++ b/.github/workflows/reusable-setup.yml
@@ -17,7 +17,7 @@ on:
       pnpm-version:
         description: 'pnpm version to install (should match packageManager in package.json)'
         type: string
-        default: '10.17.1' # UPDATE: When upgrading pnpm in package.json
+        default: '10.17.0' # UPDATE: When upgrading pnpm in package.json
       install-deps:
         description: 'Whether to install npm dependencies'
         type: boolean
@@ -33,7 +33,7 @@ on:
 #     uses: ./.github/workflows/reusable-setup.yml
 #     with:
 #       node-version: '22'
-#       pnpm-version: '10.17.1'
+#       pnpm-version: '10.17.0'
 #       install-deps: true
 #       build: true
 

--- a/.github/workflows/reusable-validate.yml
+++ b/.github/workflows/reusable-validate.yml
@@ -17,7 +17,7 @@ on:
       pnpm-version:
         description: 'pnpm version (should match package.json packageManager)'
         type: string
-        default: '10.17.1' # UPDATE: When upgrading pnpm
+        default: '10.17.0' # UPDATE: When upgrading pnpm
     secrets:
       SONAR_TOKEN:
         description: 'SonarCloud authentication token'

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -122,15 +122,15 @@ Follow these conventions to maintain code quality:
 
 When updating the pnpm version in this project, you MUST update it in ALL of the following locations to maintain consistency:
 
-1. **package.json**: Update the `packageManager` field (e.g., `"packageManager": "pnpm@10.17.1"`)
-2. **Dockerfile**: Update the version in `RUN npm install -g pnpm@10.17.1`
+1. **package.json**: Update the `packageManager` field (e.g., `"packageManager": "pnpm@10.17.0"`)
+2. **Dockerfile**: Update the version in `RUN npm install -g pnpm@10.17.0`
 3. **Documentation files**:
    - **README.md**: Update the Prerequisites section
    - **CONTRIBUTING.md**: Update the Prerequisites section
 4. **Setup script**: Update `scripts/setup.sh` for mise installation
 5. **GitHub Actions workflows** (CRITICAL - these must match package.json exactly):
-   - `.github/workflows/main.yml`: Line with `version: 10.17.1`
-   - `.github/workflows/pr.yml`: Line with `version: 10.17.1`
+   - `.github/workflows/main.yml`: Line with `version: 10.17.0`
+   - `.github/workflows/pr.yml`: Line with `version: 10.17.0`
    - `.github/workflows/publish.yml`: `PNPM_VERSION` environment variable
    - `.github/workflows/reusable-setup.yml`: Default value for `pnpm-version` input
    - `.github/workflows/reusable-security.yml`: Default value for `pnpm-version` input

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -43,7 +43,7 @@ By participating in this project, you agree to abide by our code of conduct: be 
 ### Prerequisites
 
 - Node.js 22 or higher
-- pnpm 10.17.1 or higher
+- pnpm 10.17.0 or higher
 - Git
 
 ### Setup Steps

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ WORKDIR /app
 COPY package.json pnpm-lock.yaml ./
 
 # Install pnpm and configure for production build
-RUN npm install -g pnpm@10.17.1 && \
+RUN npm install -g pnpm@10.17.0 && \
     echo "enable-pre-post-scripts=false" > .npmrc
 
 # Set environment for production build

--- a/README.md
+++ b/README.md
@@ -1164,7 +1164,7 @@ The SonarQube MCP Server follows a modular architecture:
 ### Prerequisites
 
 - Node.js 22 or higher
-- pnpm 10.17.1 or higher
+- pnpm 10.17.0 or higher
 - Docker (for container builds)
 
 ### Setup

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "bin": {
     "sonarqube-mcp-server": "./dist/index.js"
   },
-  "packageManager": "pnpm@10.17.1",
+  "packageManager": "pnpm@10.17.0",
   "scripts": {
     "dev": "tsc --watch --preserveWatchOutput",
     "start": "node dist/index.js",

--- a/scripts/setup.sh
+++ b/scripts/setup.sh
@@ -49,9 +49,9 @@ log "Checking prerequisites..."
 if ! command -v pnpm &> /dev/null; then
     if command -v mise &> /dev/null; then
         log "Installing pnpm via mise..."
-        mise install pnpm@10.17.1
+        mise install pnpm@10.17.0
     else
-        error "pnpm not found. Please install pnpm 10.17.1 or install mise first."
+        error "pnpm not found. Please install pnpm 10.17.0 or install mise first."
     fi
 fi
 


### PR DESCRIPTION
## Summary

Downgrade pnpm version from 10.17.1 to 10.17.0 across all configuration files to maintain consistency.

## Changes

- Update `packageManager` in package.json
- Update Dockerfile pnpm installation
- Update all GitHub Actions workflows
- Update documentation (README, CONTRIBUTING, CLAUDE.md)
- Update setup script
- Update changeset documentation

## Why

This ensures version consistency across all configuration files and prevents version mismatch errors in CI/CD pipelines.

## Testing

- ✅ TypeScript compilation passes
- ✅ ESLint passes
- ✅ All tests pass (900+ tests)
- ✅ Markdown lint passes
- ✅ YAML lint passes
- ✅ Prettier formatting passes

🤖 Generated with [Claude Code](https://claude.ai/code)