### PR TITLE
fix: add missing tsconfig.build.json to Docker build

### DIFF
--- a/.changeset/fix-docker-build-tsconfig.md
+++ b/.changeset/fix-docker-build-tsconfig.md
@@ -1,0 +1,19 @@
+---
+'sonarqube-mcp-server': patch
+---
+
+fix: add missing tsconfig.build.json to Docker build
+
+Fix Docker build failure by copying tsconfig.build.json to the container. The build script requires tsconfig.build.json but it was not being copied during the Docker build process, causing the build to fail with error TS5058.
+
+**Changes:**
+
+- Update Dockerfile to copy both tsconfig.json and tsconfig.build.json
+- Ensures TypeScript build process has access to the production build configuration
+- Resolves Docker build failure: "error TS5058: The specified path does not exist: 'tsconfig.build.json'"
+
+**Testing:**
+
+- Verified local build works correctly
+- Confirmed Docker build completes successfully
+- No changes to build output or functionality

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,7 +19,7 @@ RUN pnpm install --frozen-lockfile --ignore-scripts
 
 # Copy source code and build
 COPY src/ ./src/
-COPY tsconfig.json ./
+COPY tsconfig.json tsconfig.build.json ./
 RUN pnpm run build
 
 # Install production dependencies separately for clean copy


### PR DESCRIPTION
## Summary
Fixes Docker build failure by copying `tsconfig.build.json` to the container during the build process.

## Problem
The Docker build was failing with:
```
error TS5058: The specified path does not exist: 'tsconfig.build.json'.
```

This occurred because the `pnpm run build` script requires `tsconfig.build.json` but only `tsconfig.json` was being copied to the Docker container.

## Solution
Updated the Dockerfile to copy both configuration files:
```dockerfile
# Before
COPY tsconfig.json ./

# After  
COPY tsconfig.json tsconfig.build.json ./
```

## Changes
- **Updated Dockerfile**: Copy both `tsconfig.json` and `tsconfig.build.json` to container
- **Build Process**: Ensures TypeScript build has access to production build configuration
- **Error Resolution**: Fixes TS5058 path error during Docker build

## Testing
- ✅ Verified local build works correctly (`pnpm run build`)
- ✅ Confirmed Docker build completes successfully (full container build tested)
- ✅ All tests passing with no functional changes
- ✅ Type checking and linting clean

## Impact
- **No Breaking Changes**: Maintains all existing functionality
- **Build Reliability**: Docker builds now complete successfully
- **Production Ready**: Container builds work for deployments

Fixes the Docker build error reported in the issue.